### PR TITLE
Relax code block regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ demo/public
 .deploy
 test-results.xml
 
+*.swp

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,1 @@
+export const CODE_BLOCK_REGEX = /^```([\w-]+)?\s*$/;

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ import changeCurrentBlockType from "./modifiers/changeCurrentBlockType";
 import createLinkDecorator from "./decorators/link";
 import createImageDecorator from "./decorators/image";
 import { replaceText } from "./utils";
+import { CODE_BLOCK_REGEX } from "./constants";
 
 const INLINE_STYLE_CHARACTERS = [" ", "*", "_"];
 
@@ -63,7 +64,7 @@ function checkReturnForState(editorState, ev) {
   if (
     newEditorState === editorState &&
     type !== "code-block" &&
-    /^```([\w-]+)?$/.test(text)
+    CODE_BLOCK_REGEX.test(text)
   ) {
     newEditorState = handleNewCodeBlock(editorState);
   }
@@ -139,6 +140,7 @@ const createMarkdownPlugin = (config = {}) => {
       return "not-handled";
     },
     handleReturn(ev, editorState, { setEditorState }) {
+      console.log("HANDLE RETURN");
       const newEditorState = checkReturnForState(editorState, ev);
       if (editorState !== newEditorState) {
         setEditorState(newEditorState);

--- a/src/modifiers/handleNewCodeBlock.js
+++ b/src/modifiers/handleNewCodeBlock.js
@@ -1,13 +1,18 @@
 import changeCurrentBlockType from "./changeCurrentBlockType";
 import insertEmptyBlock from "./insertEmptyBlock";
+import { CODE_BLOCK_REGEX } from "../constants";
 
 const handleNewCodeBlock = editorState => {
   const contentState = editorState.getCurrentContent();
   const selection = editorState.getSelection();
   const key = selection.getStartKey();
   const currentBlock = contentState.getBlockForKey(key);
-  const matchData = /^```([\w-]+)?$/.exec(currentBlock.getText());
-  const isLast = selection.getEndOffset() === currentBlock.getLength();
+  const matchData = CODE_BLOCK_REGEX.exec(currentBlock.getText());
+  const currentText = currentBlock.getText();
+  const endOffset = selection.getEndOffset();
+  // We .trim the text here to make sure pressing enter after "``` " works even if the cursor is before the space
+  const isLast =
+    endOffset === currentText.length || endOffset === currentText.trim().length;
   if (matchData && isLast) {
     const data = {};
     const language = matchData[1];


### PR DESCRIPTION
This issue popped up in combination with the `draft-js-image-plugin`.
When an image is inserted and then deleted, the image plugin leaves an
empty line after the image.

Because this empty line is in the same block it breaks the code block
regex because suddenly it's "\`\`\` " (notice the space) rather than
"\`\`\`", so one couldn't insert a code block right before a deleted image
anymore.

By changing the code block regex to be ever so slightly more lenient
with whitespace we fix the issue.

/cc @juliankrispel this might be a bug with the `draft-js-image-plugin`?