### PR TITLE
Fix tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testRegex: "(/__tests__/.*|(\\.|/|-)(test|spec))\\.jsx?$",
+};

--- a/src/modifiers/__test__/handleImage-test.js
+++ b/src/modifiers/__test__/handleImage-test.js
@@ -1,5 +1,3 @@
-import sinon from "sinon";
-import { expect } from "chai";
 import Draft, { EditorState, SelectionState } from "draft-js";
 import handleImage from "../handleImage";
 
@@ -9,7 +7,7 @@ describe("handleImage", () => {
   let selection;
   let fakeInsertImage;
 
-  after(() => {
+  afterAll(() => {
     handleImage.__ResetDependency__("insertImage"); // eslint-disable-line no-underscore-dangle
   });
 
@@ -65,7 +63,7 @@ describe("handleImage", () => {
       "insert-image"
     );
 
-    fakeInsertImage = sinon.spy(() => newEditorState);
+    fakeInsertImage = jest.fn(() => newEditorState);
 
     handleImage.__Rewire__("insertImage", fakeInsertImage); // eslint-disable-line no-underscore-dangle
 
@@ -90,11 +88,11 @@ describe("handleImage", () => {
       it("returns new editor state", () => {
         const editorState = createEditorState(text);
         const newEditorState = handleImage(editorState, " ");
-        expect(newEditorState).not.to.equal(editorState);
-        expect(
-          Draft.convertToRaw(newEditorState.getCurrentContent())
-        ).to.deep.equal(afterRawContentState);
-        expect(fakeInsertImage).to.have.callCount(1);
+        expect(newEditorState).not.toEqual(editorState);
+        expect(Draft.convertToRaw(newEditorState.getCurrentContent())).toEqual(
+          afterRawContentState
+        );
+        expect(fakeInsertImage).toHaveBeenCalledTimes(1);
       });
     });
   });
@@ -102,8 +100,8 @@ describe("handleImage", () => {
     it("returns old editor state", () => {
       const editorState = createEditorState("yo");
       const newEditorState = handleImage(editorState, " ");
-      expect(newEditorState).to.equal(editorState);
-      expect(fakeInsertImage).not.to.have.been.called();
+      expect(newEditorState).toEqual(editorState);
+      expect(fakeInsertImage).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/modifiers/__test__/handleLink-test.js
+++ b/src/modifiers/__test__/handleLink-test.js
@@ -1,5 +1,4 @@
 import sinon from "sinon";
-import { expect } from "chai";
 import Draft, { EditorState, SelectionState } from "draft-js";
 import handleLink from "../handleLink";
 
@@ -9,7 +8,7 @@ describe("handleLink", () => {
   let selection;
   let fakeInsertLink;
 
-  after(() => {
+  afterAll(() => {
     handleLink.__ResetDependency__("../insertLink"); // eslint-disable-line no-underscore-dangle
   });
 
@@ -65,7 +64,7 @@ describe("handleLink", () => {
       "insert-image"
     );
 
-    fakeInsertLink = sinon.spy(() => newEditorState);
+    fakeInsertLink = jest.fn(() => newEditorState);
 
     handleLink.__Rewire__("insertLink", fakeInsertLink); // eslint-disable-line no-underscore-dangle
 
@@ -80,11 +79,11 @@ describe("handleLink", () => {
       it("returns new editor state", () => {
         const editorState = createEditorState(text);
         const newEditorState = handleLink(editorState, " ");
-        expect(newEditorState).not.to.equal(editorState);
-        expect(
-          Draft.convertToRaw(newEditorState.getCurrentContent())
-        ).to.deep.equal(afterRawContentState);
-        expect(fakeInsertLink).to.have.callCount(1);
+        expect(newEditorState).not.toEqual(editorState);
+        expect(Draft.convertToRaw(newEditorState.getCurrentContent())).toEqual(
+          afterRawContentState
+        );
+        expect(fakeInsertLink).toHaveBeenCalledTimes(1);
       });
     });
   });
@@ -92,8 +91,8 @@ describe("handleLink", () => {
     it("returns old editor state", () => {
       const editorState = createEditorState("yo");
       const newEditorState = handleLink(editorState, " ");
-      expect(newEditorState).to.equal(editorState);
-      expect(fakeInsertLink).not.to.have.been.called();
+      expect(newEditorState).toEqual(editorState);
+      expect(fakeInsertLink).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/modifiers/__test__/handleNewCodeBlock-test.js
+++ b/src/modifiers/__test__/handleNewCodeBlock-test.js
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import sinon from "sinon";
 import Draft, { EditorState, SelectionState } from "draft-js";
 import handleNewCodeBlock from "../handleNewCodeBlock";
@@ -49,10 +48,10 @@ describe("handleNewCodeBlock", () => {
       );
       it("creates new code block", () => {
         const newEditorState = handleNewCodeBlock(editorState);
-        expect(newEditorState).not.to.equal(editorState);
-        expect(
-          Draft.convertToRaw(newEditorState.getCurrentContent())
-        ).to.deep.equal(afterRawContentState);
+        expect(newEditorState).not.toEqual(editorState);
+        expect(Draft.convertToRaw(newEditorState.getCurrentContent())).toEqual(
+          afterRawContentState
+        );
       });
     };
 
@@ -61,10 +60,10 @@ describe("handleNewCodeBlock", () => {
   });
 
   describe("in code block", () => {
-    before(() => {
+    beforeAll(() => {
       sinon.stub(Draft, "genKey").returns("item2");
     });
-    after(() => {
+    afterAll(() => {
       Draft.genKey.restore();
     });
     const beforeRawContentState = {
@@ -119,10 +118,10 @@ describe("handleNewCodeBlock", () => {
         selection
       );
       const newEditorState = handleNewCodeBlock(editorState);
-      expect(newEditorState).not.to.equal(editorState);
-      expect(
-        Draft.convertToRaw(newEditorState.getCurrentContent())
-      ).to.deep.equal(afterRawContentState);
+      expect(newEditorState).not.toEqual(editorState);
+      expect(Draft.convertToRaw(newEditorState.getCurrentContent())).toEqual(
+        afterRawContentState
+      );
     });
     it("does not add new line even inside code block", () => {
       const selection = new SelectionState({
@@ -138,10 +137,10 @@ describe("handleNewCodeBlock", () => {
         selection
       );
       const newEditorState = handleNewCodeBlock(editorState);
-      expect(newEditorState).to.equal(editorState);
-      expect(
-        Draft.convertToRaw(newEditorState.getCurrentContent())
-      ).to.deep.equal(beforeRawContentState);
+      expect(newEditorState).toEqual(editorState);
+      expect(Draft.convertToRaw(newEditorState.getCurrentContent())).toEqual(
+        beforeRawContentState
+      );
     });
   });
 
@@ -175,10 +174,10 @@ describe("handleNewCodeBlock", () => {
     );
     it("noop", () => {
       const newEditorState = handleNewCodeBlock(editorState);
-      expect(newEditorState).to.equal(editorState);
-      expect(
-        Draft.convertToRaw(newEditorState.getCurrentContent())
-      ).to.deep.equal(rawContentState);
+      expect(newEditorState).toEqual(editorState);
+      expect(Draft.convertToRaw(newEditorState.getCurrentContent())).toEqual(
+        rawContentState
+      );
     });
   });
 });

--- a/src/modifiers/__test__/insertEmptyBlock-test.js
+++ b/src/modifiers/__test__/insertEmptyBlock-test.js
@@ -1,13 +1,12 @@
-import { expect } from "chai";
 import sinon from "sinon";
 import Draft, { EditorState, SelectionState } from "draft-js";
 import insertEmptyBlock from "../insertEmptyBlock";
 
 describe("insertEmptyBlock", () => {
-  before(() => {
+  beforeAll(() => {
     sinon.stub(Draft, "genKey").returns("item2");
   });
-  after(() => {
+  afterAll(() => {
     Draft.genKey.restore();
   });
   const testInsertEmptyBlock = (...args) => () => {
@@ -62,10 +61,10 @@ describe("insertEmptyBlock", () => {
 
     it("creates new code block", () => {
       const newEditorState = insertEmptyBlock(editorState, ...args);
-      expect(newEditorState).not.to.equal(editorState);
-      expect(
-        Draft.convertToRaw(newEditorState.getCurrentContent())
-      ).to.deep.equal(afterRawContentState);
+      expect(newEditorState).not.toEqual(editorState);
+      expect(Draft.convertToRaw(newEditorState.getCurrentContent())).toEqual(
+        afterRawContentState
+      );
     });
   };
 

--- a/src/modifiers/__test__/leaveList-test.js
+++ b/src/modifiers/__test__/leaveList-test.js
@@ -1,13 +1,12 @@
-import { expect } from "chai";
 import sinon from "sinon";
 import Draft, { EditorState, SelectionState } from "draft-js";
 import leaveList from "../leaveList";
 
 describe("leaveList", () => {
-  before(() => {
+  beforeAll(() => {
     sinon.stub(Draft, "genKey").returns("item2");
   });
-  after(() => {
+  afterAll(() => {
     Draft.genKey.restore();
   });
   [
@@ -58,10 +57,10 @@ describe("leaveList", () => {
     );
     it("converts block type", () => {
       const newEditorState = leaveList(editorState);
-      expect(newEditorState).not.to.equal(editorState);
-      expect(
-        Draft.convertToRaw(newEditorState.getCurrentContent())
-      ).to.deep.equal(afterRawContentState);
+      expect(newEditorState).not.toEqual(editorState);
+      expect(Draft.convertToRaw(newEditorState.getCurrentContent())).toEqual(
+        afterRawContentState
+      );
     });
   });
 });


### PR DESCRIPTION
When I updated the repo to use Jest I didn't realise Jest didn't handle `-test.js` files.

This updates Jest to find those tests and fixes those tests to work with Jest.