### PR TITLE
Disable all inline styling in code blocks

### DIFF
--- a/demo/webpack.config.dev.js
+++ b/demo/webpack.config.dev.js
@@ -10,8 +10,8 @@ var ExtractTextPlugin = require("extract-text-webpack-plugin");
 // host so it can load the right files. The HMR host is a bit stranger. For more
 // details on why we need this URL see the readme and:
 // https://github.com/glenjamin/webpack-hot-middleware/issues/37
-var DEV_PORT = process.env.DEV_PORT || 3001;
-var DEV_HOST = `//localhost:${DEV_PORT}/`;
+var PORT = process.env.PORT || 3001;
+var DEV_HOST = `//localhost:${PORT}/`;
 var HMR_HOST = `${DEV_HOST}__webpack_hmr`;
 
 module.exports = Object.assign(webpackBaseConfig, {

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,19 @@ import { CODE_BLOCK_REGEX } from "./constants";
 
 const INLINE_STYLE_CHARACTERS = [" ", "*", "_"];
 
+function inCodeBlock(editorState) {
+  const startKey = editorState.getSelection().getStartKey();
+  if (startKey) {
+    const currentBlockType = editorState
+      .getCurrentContent()
+      .getBlockForKey(startKey)
+      .getType();
+    if (currentBlockType === "code-block") return true;
+  }
+
+  return false;
+}
+
 function checkCharacterForState(editorState, character) {
   let newEditorState = handleBlockType(editorState, character);
   if (editorState === newEditorState) {
@@ -147,14 +160,7 @@ const createMarkdownPlugin = (config = {}) => {
       }
 
       // If we're in a code block don't add markdown to it
-      const startKey = editorState.getSelection().getStartKey();
-      if (startKey) {
-        const currentBlockType = editorState
-          .getCurrentContent()
-          .getBlockForKey(startKey)
-          .getType();
-        if (currentBlockType === "code-block") return "not-handled";
-      }
+      if (inCodeBlock(editorState)) return "not-handled";
 
       newEditorState = checkCharacterForState(editorState, "\n");
       if (editorState !== newEditorState) {
@@ -168,15 +174,9 @@ const createMarkdownPlugin = (config = {}) => {
       if (character !== " ") {
         return "not-handled";
       }
+
       // If we're in a code block don't add markdown to it
-      const startKey = editorState.getSelection().getStartKey();
-      if (startKey) {
-        const currentBlockType = editorState
-          .getCurrentContent()
-          .getBlockForKey(startKey)
-          .getType();
-        if (currentBlockType === "code-block") return "not-handled";
-      }
+      if (inCodeBlock(editorState)) return "not-handled";
 
       const newEditorState = checkCharacterForState(editorState, character);
       if (editorState !== newEditorState) {
@@ -218,6 +218,8 @@ const createMarkdownPlugin = (config = {}) => {
       if (html) {
         return "not-handled";
       }
+      // If we're in a code block don't add markdown to it
+      if (inCodeBlock(editorState)) return "not-handled";
       let newEditorState = editorState;
       let buffer = [];
       for (let i = 0; i < text.length; i++) {


### PR DESCRIPTION
We didn't properly guard pasted code, we do now!

Closes #13