### PR TITLE
Use keyBindingFn for handling enter

### DIFF
--- a/src/__test__/plugin.test.js
+++ b/src/__test__/plugin.test.js
@@ -1,4 +1,3 @@
-import sinon from "sinon";
 import Draft, { EditorState, SelectionState, ContentBlock } from "draft-js";
 import {
   CheckableListItem,
@@ -105,8 +104,11 @@ describe("draft-js-markdown-plugin", () => {
       });
       describe("handleReturn", () => {
         beforeEach(() => {
-          subject = () =>
-            plugin.handleReturn(event, store.getEditorState(), store);
+          subject = () => {
+            event = new window.KeyboardEvent("keydown", { which: 13 });
+            jest.spyOn(event, "preventDefault");
+            return plugin.keyBindingFn(event, store);
+          };
         });
         it("does not handle", () => {
           currentRawContentState = {
@@ -123,7 +125,7 @@ describe("draft-js-markdown-plugin", () => {
               },
             ],
           };
-          expect(subject()).toBe("not-handled");
+          expect(subject()).toBe(null);
           expect(modifierSpy).not.toHaveBeenCalledTimes(1);
           expect(store.setEditorState).not.toHaveBeenCalled();
         });

--- a/src/__test__/plugin.test.js
+++ b/src/__test__/plugin.test.js
@@ -104,13 +104,10 @@ describe("draft-js-markdown-plugin", () => {
       });
       describe("handleReturn", () => {
         beforeEach(() => {
-          subject = () => {
-            event = new window.KeyboardEvent("keydown", { which: 13 });
-            jest.spyOn(event, "preventDefault");
-            return plugin.keyBindingFn(event, store);
-          };
+          subject = () =>
+            plugin.handleReturn(event, store.getEditorState(), store);
         });
-        it("does not handle", () => {
+        it("does always handle", () => {
           currentRawContentState = {
             entityMap: {},
             blocks: [
@@ -125,7 +122,7 @@ describe("draft-js-markdown-plugin", () => {
               },
             ],
           };
-          expect(subject()).toBe(null);
+          expect(subject()).toBe("handled");
           expect(modifierSpy).not.toHaveBeenCalledTimes(1);
           expect(store.setEditorState).not.toHaveBeenCalled();
         });

--- a/src/index.js
+++ b/src/index.js
@@ -81,7 +81,15 @@ function checkReturnForState(editorState, ev) {
       /^header-/.test(type) ||
       type === "blockquote")
   ) {
-    newEditorState = insertEmptyBlock(editorState);
+    // transform markdown (if we aren't in a codeblock that is)
+    if (!inCodeBlock(editorState)) {
+      newEditorState = checkCharacterForState(newEditorState, "\n");
+    }
+    if (newEditorState === editorState) {
+      newEditorState = insertEmptyBlock(newEditorState);
+    } else {
+      newEditorState = RichUtils.toggleBlockType(newEditorState, type);
+    }
   }
   if (
     newEditorState === editorState &&
@@ -165,6 +173,7 @@ const createMarkdownPlugin = (config = {}) => {
       let newEditorState = checkReturnForState(editorState, ev);
       let selection = newEditorState.getSelection();
 
+      // exit code blocks
       if (
         inCodeBlock(editorState) &&
         !is(editorState.getImmutable(), newEditorState.getImmutable())

--- a/src/modifiers/__test__/changeCurrentInlineStyle-test.js
+++ b/src/modifiers/__test__/changeCurrentInlineStyle-test.js
@@ -70,18 +70,12 @@ describe("changeCurrentInlineStyle", () => {
       "\n"
     );
     expect(newEditorState).not.toEqual(editorState);
-    expect(Draft.convertToRaw(newEditorState.getCurrentContent())).toEqual(
-      rawContentState(
-        "foo bar\n baz",
-        [
-          {
-            length: 3,
-            offset: 4,
-            style: "CODE",
-          },
-        ],
-        "CODE"
-      )
-    );
+    const contentState = Draft.convertToRaw(newEditorState.getCurrentContent());
+    expect(contentState.blocks.length).toBe(2);
+    expect(contentState.blocks[0].text).toEqual("foo bar");
+    expect(contentState.blocks[0].inlineStyleRanges).toEqual([
+      { offset: 4, length: 3, style: "CODE" },
+    ]);
+    expect(contentState.blocks[1].text).toEqual(" baz");
   });
 });

--- a/src/modifiers/changeCurrentInlineStyle.js
+++ b/src/modifiers/changeCurrentInlineStyle.js
@@ -27,7 +27,7 @@ const changeCurrentInlineStyle = (editorState, matchArr, style, character) => {
     wordSelection.merge({
       anchorOffset: wordSelection.getFocusOffset() - markdownCharacterLength,
     }),
-    character || " "
+    character == null ? " " : character
   );
 
   let afterSelection = newContentState.getSelectionAfter();

--- a/src/modifiers/changeCurrentInlineStyle.js
+++ b/src/modifiers/changeCurrentInlineStyle.js
@@ -21,6 +21,8 @@ const changeCurrentInlineStyle = (editorState, matchArr, style, character) => {
 
   let newContentState = currentContent;
 
+  // if appendChar isn't defined add a space
+  // if character is a newline - add empty string and later on - split block
   let appendChar = character == null ? " " : character;
   if (character == "\n") appendChar = "";
 

--- a/src/modifiers/changeCurrentInlineStyle.js
+++ b/src/modifiers/changeCurrentInlineStyle.js
@@ -21,13 +21,16 @@ const changeCurrentInlineStyle = (editorState, matchArr, style, character) => {
 
   let newContentState = currentContent;
 
+  let appendChar = character == null ? " " : character;
+  if (character == "\n") appendChar = "";
+
   // remove markdown delimiter at end
   newContentState = Modifier.replaceText(
     newContentState,
     wordSelection.merge({
       anchorOffset: wordSelection.getFocusOffset() - markdownCharacterLength,
     }),
-    character == null ? " " : character
+    appendChar
   );
 
   let afterSelection = newContentState.getSelectionAfter();
@@ -55,6 +58,11 @@ const changeCurrentInlineStyle = (editorState, matchArr, style, character) => {
     }),
     style
   );
+
+  if (character == "\n") {
+    newContentState = Modifier.splitBlock(newContentState, afterSelection);
+    afterSelection = newContentState.getSelectionAfter();
+  }
 
   const newEditorState = EditorState.push(
     editorState,

--- a/src/modifiers/resetInlineStyle.js
+++ b/src/modifiers/resetInlineStyle.js
@@ -2,4 +2,6 @@ import { OrderedSet } from "immutable";
 import { EditorState } from "draft-js";
 
 export default editorState =>
-  EditorState.setInlineStyleOverride(editorState, OrderedSet());
+  editorState.getCurrentInlineStyle().size === 0
+    ? editorState
+    : EditorState.setInlineStyleOverride(editorState, OrderedSet());

--- a/src/modifiers/resetInlineStyle.js
+++ b/src/modifiers/resetInlineStyle.js
@@ -1,0 +1,5 @@
+import { OrderedSet } from "immutable";
+import { EditorState } from "draft-js";
+
+export default editorState =>
+  EditorState.setInlineStyleOverride(editorState, OrderedSet());


### PR DESCRIPTION
- [x] transform markdown in list items
- [x] split block rather than newlines when transforming markdown upon hitting `enter` key
- [x] reset inline style upon return
- [x] transform markdown

- fixes #24
- fixes #29
