### PR TITLE
codeblock language switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,48 @@ A [DraftJS] plugin for supporting Markdown syntax shortcuts in DraftJS. This plu
 npm i --save draft-js-markdown-plugin
 ```
 
+## Options
+The `draft-js-markdown-plugin` is configurable. Just pass a config object. Here are the available options:
+
+
+### `renderLanguageSelect`
+
+```js
+renderLanguageSelect = ({
+  // Array of language options
+  options: Array<{ label, value }>,
+  // Callback to select an option
+  onChange: (selectedValue: string) => void,
+  // Value of selected option
+  selectedValue: string,
+  // Label of selected option
+  selectedLabel: string
+}) => React.Node
+```
+
+Code blocks render a select to switch syntax highlighting - `renderLanguageSelect` is a render function that lets you override how this is rendered. 
+
+Here's an example:
+
+```
+import createMarkdownPlugin from 'draft-js-markdown-plugin';
+
+const renderLanguageSelect = ({ options, onChange, selectedValue }) => (
+  <select value={selectedValue} onChange={onChange}>
+    {options.map(({ label, value }) => (
+      <option key={value} value={value}>
+        {label}
+      </option>
+    ))}
+  </select>
+);
+
+const markdownPlugin = createMarkdownPlugin({ renderLanguageSelect })
+```
+
+### `languages`
+Dictionary for languages available to code block switcher
+
 ## Usage
 
 ```js

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ renderLanguageSelect = ({
 
 Code blocks render a select to switch syntax highlighting - `renderLanguageSelect` is a render function that lets you override how this is rendered. 
 
-Here's an example:
+#### Example:
 
 ```
 import createMarkdownPlugin from 'draft-js-markdown-plugin';
@@ -58,6 +58,16 @@ const markdownPlugin = createMarkdownPlugin({ renderLanguageSelect })
 
 ### `languages`
 Dictionary for languages available to code block switcher
+
+#### Example:
+
+```js
+const languages = {
+  js: 'JavaScript'
+}
+
+const markdownPlugin = createMarkdownPlugin({ languages })
+```
 
 ## Usage
 

--- a/demo/client/components/DemoEditor/index.js
+++ b/demo/client/components/DemoEditor/index.js
@@ -45,6 +45,7 @@ export default class DemoEditor extends Component {
   };
 
   focus = () => {
+    console.log("damnit");
     this.editor.focus();
   };
 
@@ -52,7 +53,7 @@ export default class DemoEditor extends Component {
     const { editorState } = this.state;
     return (
       <div className={styles.root}>
-        <div className={styles.editor}>
+        <div className={styles.editor} onClick={this.focus}>
           <Editor
             editorState={editorState}
             onChange={this.onChange}

--- a/demo/client/components/DemoEditor/index.js
+++ b/demo/client/components/DemoEditor/index.js
@@ -27,7 +27,36 @@ const prismPlugin = createPrismPlugin({
   prism: Prism,
 });
 
-const plugins = [prismPlugin, createMarkdownShortcutsPlugin()];
+const renderLanguageSelect = ({
+  options,
+  onChange,
+  selectedValue,
+  selectedLabel,
+}) => (
+  <div className={styles.switcherContainer}>
+    <div className={styles.switcher}>
+      <select
+        className={styles.switcherSelect}
+        value={selectedValue}
+        onChange={onChange}
+      >
+        {options.map(({ label, value }) => (
+          <option key={value} value={value}>
+            {label}
+          </option>
+        ))}
+      </select>
+      <div className={styles.switcherLabel}>
+        {selectedLabel} {String.fromCharCode(9662)}
+      </div>
+    </div>
+  </div>
+);
+
+const plugins = [
+  prismPlugin,
+  createMarkdownShortcutsPlugin({ renderLanguageSelect }),
+];
 
 const initialEditorState = EditorState.createWithContent(
   convertFromRaw(initialState)
@@ -45,7 +74,6 @@ export default class DemoEditor extends Component {
   };
 
   focus = () => {
-    console.log("damnit");
     this.editor.focus();
   };
 

--- a/demo/client/components/DemoEditor/index.js
+++ b/demo/client/components/DemoEditor/index.js
@@ -53,6 +53,12 @@ const renderLanguageSelect = ({
   </div>
 );
 
+const languages = {
+  js: "JavaScript",
+  kotlin: "Kotlin",
+  mathml: "MathML",
+};
+
 const plugins = [
   prismPlugin,
   createMarkdownShortcutsPlugin({ renderLanguageSelect }),

--- a/demo/client/components/DemoEditor/index.js
+++ b/demo/client/components/DemoEditor/index.js
@@ -52,7 +52,7 @@ export default class DemoEditor extends Component {
     const { editorState } = this.state;
     return (
       <div className={styles.root}>
-        <div className={styles.editor} onClick={this.focus}>
+        <div className={styles.editor}>
           <Editor
             editorState={editorState}
             onChange={this.onChange}

--- a/demo/client/components/DemoEditor/styles.css
+++ b/demo/client/components/DemoEditor/styles.css
@@ -11,3 +11,37 @@
   height: 100%;
   width: 100%;
 }
+
+pre {
+  background: #f9f9f9;
+  padding: 0.2em 0.5em;
+  position: relative;
+}
+
+.switcherContainer {
+  position: absolute;
+  text-align: right;
+  bottom: -23px;
+  right: 3px;
+}
+
+.switcher {
+  display: inline-block;
+  font-family: sans-serif;
+  color: #ccc;
+  letter-spacing: 0.05em;
+  font-size: 12px;
+  padding: 0.3em;
+  cursor: pointer;
+  position: relative;
+}
+
+.switcherSelect {
+  position: absolute;
+  top: 0;
+  cursor: pointer;
+  opacity: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "draft-js-plugins-editor": "~2.0.0-rc.1 || 2.0.0-rc2 || 2.0.0-rc1 || 2.0.0-beta12",
     "react": "^15.0.0",
     "react-dom": "^15.0.0",
-    "react-modal": "3.x",
     "react-portal": "^4.1.4"
   },
   "contributors": [
@@ -108,7 +107,6 @@
     "draft-js-checkable-list-item": "^2.0.5",
     "draft-js-prism-plugin": "^0.1.1",
     "immutable": "~3.7.4",
-    "react-modal": "^3.3.2",
-    "react-popover": "^0.4.0"
+    "react-click-outside": "^3.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "flow-bin": "^0.36.0",
     "history": "^2.0.0",
     "husky": "^0.14.3",
+    "jest": "^21.1.0",
     "jsdom": "^9.8.3",
     "lint-staged": "^4.2.1",
     "mocha": "^3.2.0",
@@ -81,6 +82,7 @@
     "react-dom": "^15.4.1",
     "react-github-corner": "^2.0.0",
     "react-github-fork-ribbon": "^0.4.4",
+    "react-test-renderer": "^16.2.0",
     "rimraf": "^2.5.4",
     "sinon": "^1.17.6",
     "static-site-generator-webpack-plugin": "^3.1.0",
@@ -88,23 +90,25 @@
     "url-loader": "^0.5.7",
     "webpack": "^1.13.3",
     "webpack-dev-middleware": "^1.8.4",
-    "webpack-hot-middleware": "^2.13.2",
-    "jest": "^21.1.0",
-    "react-test-renderer": "^16.2.0"
+    "webpack-hot-middleware": "^2.13.2"
   },
   "peerDependencies": {
     "draft-js-plugins-editor": "~2.0.0-rc.1 || 2.0.0-rc2 || 2.0.0-rc1 || 2.0.0-beta12",
     "react": "^15.0.0",
-    "react-dom": "^15.0.0"
+    "react-dom": "^15.0.0",
+    "react-modal": "3.x",
+    "react-portal": "^4.1.4"
   },
   "contributors": [
     "Atsushi Nagase <a@ngs.io>"
   ],
   "dependencies": {
     "decorate-component-with-props": "^1.0.2",
-    "draft-js": "~0.10.1",
+    "draft-js": "^0.10.4",
     "draft-js-checkable-list-item": "^2.0.5",
     "draft-js-prism-plugin": "^0.1.1",
-    "immutable": "~3.7.4"
+    "immutable": "~3.7.4",
+    "react-modal": "^3.3.2",
+    "react-popover": "^0.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean": "node_modules/.bin/rimraf lib; node_modules/.bin/rimraf demo/public",
     "dev": "node_modules/.bin/babel-node ./demo/server.js",
     "test": "jest",
-    "precommit": "lint-staged"
+    "precommit": "jest && lint-staged"
   },
   "repository": {
     "type": "git",

--- a/src/components/Code/index.js
+++ b/src/components/Code/index.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from "react";
 import { Map } from "immutable";
 import { EditorState, EditorBlock, Modifier } from "draft-js";
+import Modal from "react-modal";
 
 const languages = {
   bash: "Bash",
@@ -22,11 +23,22 @@ const languages = {
   swift: "Swift",
 };
 
+const hidden = {};
+
 class CodeBlock extends PureComponent {
+  state = {
+    isOpen: false,
+  };
+
   onChange = ev => {
     ev.preventDefault();
+    ev.stopPropagation();
     const blockKey = this.props.block.getKey();
-    const { getEditorState, setEditorState } = this.props.blockProps;
+    const {
+      getEditorState,
+      setEditorState,
+      getEditorRef,
+    } = this.props.blockProps;
     const editorState = getEditorState();
     const selection = editorState.getSelection();
     const language = ev.currentTarget.value;
@@ -40,12 +52,19 @@ class CodeBlock extends PureComponent {
       "change-block-data"
     );
 
-    // setTimeout(() => {
-    //   setEditorState(EditorState.forceSelection(
-    //     newEditorState,
-    //     content.getSelectionAfter()
-    //   ))
-    // }, 3000)
+    setTimeout(() => {
+      setEditorState(
+        EditorState.forceSelection(newEditorState, content.getSelectionAfter())
+      );
+    }, 2);
+  };
+
+  cancelClicks = event => event.preventDefault();
+
+  preventBubbling = event => event.stopPropagation();
+
+  wat = () => {
+    console.log("yo wtf");
   };
 
   render() {
@@ -54,8 +73,13 @@ class CodeBlock extends PureComponent {
     return (
       <div>
         <EditorBlock {...this.props} />
-        <div contentEditable={false}>
-          <select value={language} onChange={this.onChange}>
+        <div>
+          <select
+            contentEditable={false}
+            onClick={this.preventBubbling}
+            value={language}
+            onChange={this.onChange}
+          >
             {Object.keys(this.props.languages).map(lang => (
               <option key={lang} value={lang}>
                 {this.props.languages[lang]}

--- a/src/components/Code/index.js
+++ b/src/components/Code/index.js
@@ -8,25 +8,6 @@ const alias = {
   jsx: "js",
 };
 
-const languages = {
-  bash: "Bash",
-  c: "C",
-  cpp: "C++",
-  css: "CSS",
-  go: "Go",
-  html: "HTML",
-  java: "Java",
-  js: "JavaScript",
-  kotlin: "Kotlin",
-  mathml: "MathML",
-  perl: "Perl",
-  ruby: "Ruby",
-  scala: "Scala",
-  sql: "SQL",
-  svg: "SVG",
-  swift: "Swift",
-};
-
 const CodeSwitchContainer = enhanceWithClickOutside(
   class SwitchContainer extends PureComponent {
     handleClickOutside() {
@@ -103,12 +84,15 @@ class CodeBlock extends PureComponent {
     const editorState = getEditorState();
     const selection = editorState.getSelection();
 
-    setEditorState(EditorState.forceSelection(newEditorState, selection));
+    setEditorState(EditorState.forceSelection(editorState, selection));
   };
 
   render() {
-    const { languages, blockProps } = this.props;
-    const { renderLanguageSelect, language: _language } = blockProps;
+    const {
+      languages,
+      renderLanguageSelect,
+      language: _language,
+    } = this.props.blockProps;
 
     const language = alias[_language] || _language;
     const selectedLabel = languages[language];
@@ -143,9 +127,5 @@ class CodeBlock extends PureComponent {
     );
   }
 }
-
-CodeBlock.defaultProps = {
-  languages,
-};
 
 export default CodeBlock;

--- a/src/components/Code/index.js
+++ b/src/components/Code/index.js
@@ -1,0 +1,75 @@
+import React, { PureComponent } from "react";
+import { Map } from "immutable";
+import { EditorState, EditorBlock, Modifier } from "draft-js";
+
+const languages = {
+  bash: "Bash",
+  c: "C",
+  cpp: "C++",
+  css: "CSS",
+  go: "Go",
+  html: "HTML",
+  java: "Java",
+  javascript: "JavaScript",
+  js: "JavaScript",
+  kotlin: "Kotlin",
+  mathml: "MathML",
+  perl: "Perl",
+  ruby: "Ruby",
+  scala: "Scala",
+  sql: "SQL",
+  svg: "SVG",
+  swift: "Swift",
+};
+
+class CodeBlock extends PureComponent {
+  onChange = ev => {
+    ev.preventDefault();
+    const blockKey = this.props.block.getKey();
+    const { getEditorState, setEditorState } = this.props.blockProps;
+    const editorState = getEditorState();
+    const selection = editorState.getSelection();
+    const language = ev.currentTarget.value;
+
+    let content = editorState.getCurrentContent();
+    content = Modifier.mergeBlockData(content, selection, Map({ language }));
+
+    const newEditorState = EditorState.push(
+      editorState,
+      content,
+      "change-block-data"
+    );
+
+    // setTimeout(() => {
+    //   setEditorState(EditorState.forceSelection(
+    //     newEditorState,
+    //     content.getSelectionAfter()
+    //   ))
+    // }, 3000)
+  };
+
+  render() {
+    const { language } = this.props.blockProps;
+
+    return (
+      <div>
+        <EditorBlock {...this.props} />
+        <div contentEditable={false}>
+          <select value={language} onChange={this.onChange}>
+            {Object.keys(this.props.languages).map(lang => (
+              <option key={lang} value={lang}>
+                {this.props.languages[lang]}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+    );
+  }
+}
+
+CodeBlock.defaultProps = {
+  languages,
+};
+
+export default CodeBlock;

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,3 +6,5 @@ export const inlineMatchers = {
   CODE: [/`([^`]+)`/g],
   STRIKETHROUGH: [/~~([^(?:~~)]+)~~/g],
 };
+
+export const CODE_BLOCK_TYPE = "code-block";

--- a/src/decorators/image/index.js
+++ b/src/decorators/image/index.js
@@ -1,8 +1,8 @@
 import createImageStrategy from "./imageStrategy";
 import Image from "../../components/Image";
 
-const createImageDecorator = (config, store) => ({
-  strategy: createImageStrategy(config, store),
+const createImageDecorator = () => ({
+  strategy: createImageStrategy(),
   component: Image,
 });
 

--- a/src/decorators/link/index.js
+++ b/src/decorators/link/index.js
@@ -1,8 +1,8 @@
 import createLinkStrategy from "./linkStrategy";
 import Link from "../../components/Link";
 
-const createLinkDecorator = (config, store) => ({
-  strategy: createLinkStrategy(config, store),
+const createLinkDecorator = () => ({
+  strategy: createLinkStrategy(),
   component: Link,
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -126,7 +126,7 @@ const createMarkdownPlugin = (config = {}) => {
       return null;
     },
 
-    blockRendererFn(block, { setEditorState, getEditorState }) {
+    blockRendererFn(block, { setEditorState, getEditorState, getEditorRef }) {
       switch (block.getType()) {
         case CHECKABLE_LIST_ITEM: {
           return {
@@ -144,6 +144,7 @@ const createMarkdownPlugin = (config = {}) => {
           return {
             component: CodeBlock,
             props: {
+              getEditorRef,
               setEditorState,
               language: block.getData().get("language"),
               getEditorState,

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import {
 
 import { Map } from "immutable";
 
+import CodeBlock from "./components/Code";
 import adjustBlockDepth from "./modifiers/adjustBlockDepth";
 import handleBlockType from "./modifiers/handleBlockType";
 import handleInlineStyle from "./modifiers/handleInlineStyle";
@@ -21,7 +22,7 @@ import changeCurrentBlockType from "./modifiers/changeCurrentBlockType";
 import createLinkDecorator from "./decorators/link";
 import createImageDecorator from "./decorators/image";
 import { replaceText } from "./utils";
-import { CODE_BLOCK_REGEX } from "./constants";
+import { CODE_BLOCK_REGEX, CODE_BLOCK_TYPE } from "./constants";
 
 const INLINE_STYLE_CHARACTERS = [" ", "*", "_"];
 
@@ -104,7 +105,7 @@ const createMarkdownPlugin = (config = {}) => {
     blockRenderMap: Map({
       "code-block": {
         element: "code",
-        wrapper: <pre spellCheck={"false"} />,
+        wrapper: <pre spellCheck="false" />,
       },
     }).merge(checkboxBlockRenderMap),
     decorators: [
@@ -139,6 +140,17 @@ const createMarkdownPlugin = (config = {}) => {
             },
           };
         }
+        case CODE_BLOCK_TYPE: {
+          return {
+            component: CodeBlock,
+            props: {
+              setEditorState,
+              language: block.getData().get("language"),
+              getEditorState,
+            },
+          };
+        }
+
         default:
           return null;
       }

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,25 @@ import createImageDecorator from "./decorators/image";
 import { replaceText } from "./utils";
 import { CODE_BLOCK_REGEX, CODE_BLOCK_TYPE } from "./constants";
 
+const defaultLanguages = {
+  bash: "Bash",
+  c: "C",
+  cpp: "C++",
+  css: "CSS",
+  go: "Go",
+  html: "HTML",
+  java: "Java",
+  js: "JavaScript",
+  kotlin: "Kotlin",
+  mathml: "MathML",
+  perl: "Perl",
+  ruby: "Ruby",
+  scala: "Scala",
+  sql: "SQL",
+  svg: "SVG",
+  swift: "Swift",
+};
+
 const INLINE_STYLE_CHARACTERS = [" ", "*", "_"];
 
 const defaultRenderSelect = ({ options, onChange, selectedValue }) => (
@@ -110,6 +129,7 @@ function checkReturnForState(editorState, ev) {
 
 const defaultConfig = {
   renderLanguageSelect: defaultRenderSelect,
+  languages: defaultLanguages,
 };
 
 const createMarkdownPlugin = (_config = {}) => {
@@ -128,10 +148,7 @@ const createMarkdownPlugin = (_config = {}) => {
         wrapper: <pre spellCheck="false" />,
       },
     }).merge(checkboxBlockRenderMap),
-    decorators: [
-      createLinkDecorator(config, store),
-      createImageDecorator(config, store),
-    ],
+    decorators: [createLinkDecorator(), createImageDecorator()],
     initialize({ setEditorState, getEditorState }) {
       store.setEditorState = setEditorState;
       store.getEditorState = getEditorState;
@@ -169,6 +186,7 @@ const createMarkdownPlugin = (_config = {}) => {
             props: {
               setEditorState,
               renderLanguageSelect: config.renderLanguageSelect,
+              languages: config.languages,
               setReadOnly,
               language: block.getData().get("language"),
               getEditorState,

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,16 @@ import { CODE_BLOCK_REGEX, CODE_BLOCK_TYPE } from "./constants";
 
 const INLINE_STYLE_CHARACTERS = [" ", "*", "_"];
 
+const defaultRenderSelect = ({ options, onChange, selectedValue }) => (
+  <select value={selectedValue} onChange={onChange}>
+    {options.map(({ label, value }) => (
+      <option key={value} value={value}>
+        {label}
+      </option>
+    ))}
+  </select>
+);
+
 function inCodeBlock(editorState) {
   const startKey = editorState.getSelection().getStartKey();
   if (startKey) {
@@ -98,8 +108,18 @@ function checkReturnForState(editorState, ev) {
   return newEditorState;
 }
 
-const createMarkdownPlugin = (config = {}) => {
+const defaultConfig = {
+  renderLanguageSelect: defaultRenderSelect,
+};
+
+const createMarkdownPlugin = (_config = {}) => {
   const store = {};
+
+  const config = {
+    ...defaultConfig,
+    ..._config,
+  };
+
   return {
     store,
     blockRenderMap: Map({
@@ -126,7 +146,10 @@ const createMarkdownPlugin = (config = {}) => {
       return null;
     },
 
-    blockRendererFn(block, { setEditorState, getEditorState, getEditorRef }) {
+    blockRendererFn(
+      block,
+      { setReadOnly, setEditorState, getEditorState, getEditorRef }
+    ) {
       switch (block.getType()) {
         case CHECKABLE_LIST_ITEM: {
           return {
@@ -144,8 +167,9 @@ const createMarkdownPlugin = (config = {}) => {
           return {
             component: CodeBlock,
             props: {
-              getEditorRef,
               setEditorState,
+              renderLanguageSelect: config.renderLanguageSelect,
+              setReadOnly,
               language: block.getData().get("language"),
               getEditorState,
             },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1546,6 +1546,14 @@ create-error-class@^3.0.0:
   dependencies:
     capture-stack-trace "^1.0.0"
 
+create-react-class@^15.5.3:
+  version "15.6.3"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 create-react-class@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.0.tgz#ab448497c26566e1e29413e883207d57cfe7bed4"
@@ -1652,6 +1660,12 @@ css-selector-tokenizer@^0.7.0:
     cssesc "^0.1.0"
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
+
+css-vendor@^0.3.1:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/css-vendor/-/css-vendor-0.3.8.tgz#6421cfd3034ce664fe7673972fd0119fc28941fa"
+  dependencies:
+    is-in-browser "^1.0.2"
 
 css-what@2.1:
   version "2.1.0"
@@ -1922,7 +1936,15 @@ draft-js-prism@ngs/draft-js-prism#6edb31c3805dd1de3fb897cc27fced6bac1bafbb:
     immutable "*"
     prismjs "^1.5.0"
 
-draft-js@~0.10.0, draft-js@~0.10.1:
+draft-js@^0.10.4:
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/draft-js/-/draft-js-0.10.5.tgz#bfa9beb018fe0533dbb08d6675c371a6b08fa742"
+  dependencies:
+    fbjs "^0.8.15"
+    immutable "~3.7.4"
+    object-assign "^4.1.0"
+
+draft-js@~0.10.0:
   version "0.10.2"
   resolved "https://registry.yarnpkg.com/draft-js/-/draft-js-0.10.2.tgz#b722613cb306cfee910f9de1789f2cc3023772e7"
   dependencies:
@@ -2323,6 +2345,10 @@ execa@^0.8.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+exenv@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
+
 exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
@@ -2435,7 +2461,7 @@ fbjs@^0.8.12:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
-fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.9:
+fbjs@^0.8.15, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -3173,6 +3199,10 @@ is-glob@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0"
   dependencies:
     is-extglob "^2.1.1"
+
+is-in-browser@^1.0.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-in-browser/-/is-in-browser-1.1.3.tgz#56ff4db683a078c6082eb95dad7dc62e1d04f835"
 
 is-my-json-valid@^2.10.0, is-my-json-valid@^2.12.4:
   version "2.16.1"
@@ -3949,6 +3979,12 @@ lodash.create@3.1.1:
     lodash._basecreate "^3.0.0"
     lodash._isiterateecall "^3.0.0"
 
+lodash.debounce@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-3.1.1.tgz#812211c378a94cc29d5aa4e3346cf0bfce3a7df5"
+  dependencies:
+    lodash._getnative "^3.0.0"
+
 lodash.defaults@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-3.1.2.tgz#c7308b18dbf8bc9372d701a73493c61192bd2e2c"
@@ -4019,6 +4055,12 @@ lodash.restparam@^3.0.0:
 lodash.some@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
+
+lodash.throttle@^3.0.3:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-3.0.4.tgz#bc4f471fb328e4d6fdc6df2b3d3caf113f0f89c9"
+  dependencies:
+    lodash.debounce "^3.0.0"
 
 lodash.uniq@^4.5.0:
   version "4.5.0"
@@ -5255,6 +5297,10 @@ react-deep-force-update@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-1.1.1.tgz#bcd31478027b64b3339f108921ab520b4313dc2c"
 
+react-dom-factories@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-dom-factories/-/react-dom-factories-1.0.2.tgz#eb7705c4db36fb501b3aa38ff759616aa0ff96e0"
+
 react-dom@^15.4.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.1.tgz#2cb0ed4191038e53c209eb3a79a23e2a4cf99470"
@@ -5271,6 +5317,25 @@ react-github-corner@^2.0.0:
 react-github-fork-ribbon@^0.4.4:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/react-github-fork-ribbon/-/react-github-fork-ribbon-0.4.5.tgz#2d3586bfde368a19aef7b4a46471e0839c9bc010"
+
+react-modal@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.3.2.tgz#b13da9490653a7c76bc0e9600323eb1079c620e7"
+  dependencies:
+    exenv "^1.2.0"
+    prop-types "^15.5.10"
+    warning "^3.0.0"
+
+react-popover@^0.4.0:
+  version "0.4.18"
+  resolved "https://registry.yarnpkg.com/react-popover/-/react-popover-0.4.18.tgz#c8a5aacdddf5a883068368ea1f589dfd3bdd4943"
+  dependencies:
+    create-react-class "^15.5.3"
+    css-vendor "^0.3.1"
+    debug "^2.6.8"
+    lodash.throttle "^3.0.3"
+    prop-types "^15.5.10"
+    react-dom-factories "^1.0.0"
 
 react-proxy@^1.1.7:
   version "1.1.8"
@@ -5298,9 +5363,19 @@ react-transform-hmr@^1.0.3:
     global "^4.3.0"
     react-proxy "^1.1.7"
 
-react@*, react@^15.4.1:
+react@*:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/react/-/react-15.6.1.tgz#baa8434ec6780bde997cdc380b79cd33b96393df"
+  dependencies:
+    create-react-class "^15.6.0"
+    fbjs "^0.8.9"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.0"
+    prop-types "^15.5.10"
+
+react@^15.4.1:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
   dependencies:
     create-react-class "^15.6.0"
     fbjs "^0.8.9"
@@ -6397,6 +6472,12 @@ walker@~1.0.5:
 warning@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/warning/-/warning-2.1.0.tgz#21220d9c63afc77a8c92111e011af705ce0c6901"
+  dependencies:
+    loose-envify "^1.0.0"
+
+warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
   dependencies:
     loose-envify "^1.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1546,14 +1546,6 @@ create-error-class@^3.0.0:
   dependencies:
     capture-stack-trace "^1.0.0"
 
-create-react-class@^15.5.3:
-  version "15.6.3"
-  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
-
 create-react-class@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.0.tgz#ab448497c26566e1e29413e883207d57cfe7bed4"
@@ -1660,12 +1652,6 @@ css-selector-tokenizer@^0.7.0:
     cssesc "^0.1.0"
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
-
-css-vendor@^0.3.1:
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/css-vendor/-/css-vendor-0.3.8.tgz#6421cfd3034ce664fe7673972fd0119fc28941fa"
-  dependencies:
-    is-in-browser "^1.0.2"
 
 css-what@2.1:
   version "2.1.0"
@@ -2345,10 +2331,6 @@ execa@^0.8.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-exenv@^1.2.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
-
 exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
@@ -2916,6 +2898,10 @@ hoek@4.x.x:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
 
+hoist-non-react-statics@^2.1.1:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -3199,10 +3185,6 @@ is-glob@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0"
   dependencies:
     is-extglob "^2.1.1"
-
-is-in-browser@^1.0.2:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/is-in-browser/-/is-in-browser-1.1.3.tgz#56ff4db683a078c6082eb95dad7dc62e1d04f835"
 
 is-my-json-valid@^2.10.0, is-my-json-valid@^2.12.4:
   version "2.16.1"
@@ -3979,12 +3961,6 @@ lodash.create@3.1.1:
     lodash._basecreate "^3.0.0"
     lodash._isiterateecall "^3.0.0"
 
-lodash.debounce@^3.0.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-3.1.1.tgz#812211c378a94cc29d5aa4e3346cf0bfce3a7df5"
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash.defaults@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-3.1.2.tgz#c7308b18dbf8bc9372d701a73493c61192bd2e2c"
@@ -4055,12 +4031,6 @@ lodash.restparam@^3.0.0:
 lodash.some@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
-
-lodash.throttle@^3.0.3:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-3.0.4.tgz#bc4f471fb328e4d6fdc6df2b3d3caf113f0f89c9"
-  dependencies:
-    lodash.debounce "^3.0.0"
 
 lodash.uniq@^4.5.0:
   version "4.5.0"
@@ -5293,13 +5263,15 @@ react-addons-test-utils@^15.4.1:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.6.0.tgz#062d36117fe8d18f3ba5e06eb33383b0b85ea5b9"
 
+react-click-outside@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/react-click-outside/-/react-click-outside-3.0.1.tgz#6e77e84d2f17afaaac26dbad743cbbf909f5e24c"
+  dependencies:
+    hoist-non-react-statics "^2.1.1"
+
 react-deep-force-update@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-1.1.1.tgz#bcd31478027b64b3339f108921ab520b4313dc2c"
-
-react-dom-factories@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/react-dom-factories/-/react-dom-factories-1.0.2.tgz#eb7705c4db36fb501b3aa38ff759616aa0ff96e0"
 
 react-dom@^15.4.1:
   version "15.6.1"
@@ -5317,25 +5289,6 @@ react-github-corner@^2.0.0:
 react-github-fork-ribbon@^0.4.4:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/react-github-fork-ribbon/-/react-github-fork-ribbon-0.4.5.tgz#2d3586bfde368a19aef7b4a46471e0839c9bc010"
-
-react-modal@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.3.2.tgz#b13da9490653a7c76bc0e9600323eb1079c620e7"
-  dependencies:
-    exenv "^1.2.0"
-    prop-types "^15.5.10"
-    warning "^3.0.0"
-
-react-popover@^0.4.0:
-  version "0.4.18"
-  resolved "https://registry.yarnpkg.com/react-popover/-/react-popover-0.4.18.tgz#c8a5aacdddf5a883068368ea1f589dfd3bdd4943"
-  dependencies:
-    create-react-class "^15.5.3"
-    css-vendor "^0.3.1"
-    debug "^2.6.8"
-    lodash.throttle "^3.0.3"
-    prop-types "^15.5.10"
-    react-dom-factories "^1.0.0"
 
 react-proxy@^1.1.7:
   version "1.1.8"
@@ -6472,12 +6425,6 @@ walker@~1.0.5:
 warning@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/warning/-/warning-2.1.0.tgz#21220d9c63afc77a8c92111e011af705ce0c6901"
-  dependencies:
-    loose-envify "^1.0.0"
-
-warning@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
   dependencies:
     loose-envify "^1.0.0"
 


### PR DESCRIPTION
So I believe we want this - a language switcher for code blocks

![language switche](https://spectrum.imgix.net/threads/1d9e1699-0902-458a-89a3-2bbf6a81d775/Screen%20Recording%202017-11-01%20at%2009.07%20AM.gif.0.3602711804770595?max-w=1440)

draft-js editors often use click events (to focus on the editor or whatever) so I'd use react-portal to display the language selection menu.

Are there any components that you guys already use or that you prefer using? It's just that there are hundreds of components like these - so any pointers as to how you'd like to have it implemented would be cool.

cc @mxstbr 