### PR TITLE
Do not convert block type if current block type is not simple

### DIFF
--- a/src/modifiers/__test__/handleBlockType-test.js
+++ b/src/modifiers/__test__/handleBlockType-test.js
@@ -39,6 +39,44 @@ describe("handleBlockType", () => {
     });
   });
 
+  describe("when current block type is not 'unstyled' or 'paragraph'", () => {
+    const rawContentState = {
+      entityMap: {},
+      blocks: [
+        {
+          key: "item1",
+          text: "# Header",
+          type: "unordered-list-item",
+          depth: 0,
+          inlineStyleRanges: [],
+          entityRanges: [],
+          data: {},
+        },
+      ],
+    };
+    const contentState = Draft.convertFromRaw(rawContentState);
+    const selection = new SelectionState({
+      anchorKey: "item1",
+      anchorOffset: 3,
+      focusKey: "item1",
+      focusOffset: 3,
+      isBackward: false,
+      hasFocus: true,
+    });
+    const editorState = EditorState.forceSelection(
+      EditorState.createWithContent(contentState),
+      selection
+    );
+
+    it("does not convert block type", () => {
+      const newEditorState = handleBlockType(editorState, " ");
+      expect(newEditorState).toEqual(editorState);
+      expect(Draft.convertToRaw(newEditorState.getCurrentContent())).toEqual(
+        rawContentState
+      );
+    });
+  });
+
   const testCases = {
     "converts from unstyled to header-one": {
       before: {

--- a/src/modifiers/handleBlockType.js
+++ b/src/modifiers/handleBlockType.js
@@ -32,44 +32,49 @@ const handleBlockType = (editorState, character) => {
     ""
   );
   const blockType = RichUtils.getCurrentBlockType(editorState);
-  for (let i = 1; i <= 6; i += 1) {
-    if (line.indexOf(`${sharps(i)} `) === 0) {
+
+  if (blockType === "unstyled" || blockType === "paragraph") {
+    for (let i = 1; i <= 6; i += 1) {
+      if (line.indexOf(`${sharps(i)} `) === 0) {
+        return changeCurrentBlockType(
+          editorState,
+          blockTypes[i],
+          line.replace(/^#+\s/, "")
+        );
+      }
+    }
+    let matchArr = line.match(/^[*-] (.*)$/);
+    if (matchArr) {
       return changeCurrentBlockType(
         editorState,
-        blockTypes[i],
-        line.replace(/^#+\s/, "")
+        "unordered-list-item",
+        matchArr[1]
+      );
+    }
+    matchArr = line.match(/^[\d]\. (.*)$/);
+    if (matchArr) {
+      return changeCurrentBlockType(
+        editorState,
+        "ordered-list-item",
+        matchArr[1]
+      );
+    }
+    matchArr = line.match(/^> (.*)$/);
+    if (matchArr) {
+      return changeCurrentBlockType(editorState, "blockquote", matchArr[1]);
+    }
+  } else if (blockType === "unordered-list-item") {
+    let matchArr = line.match(/^\[([x ])] (.*)$/i);
+    if (matchArr) {
+      return changeCurrentBlockType(
+        editorState,
+        CHECKABLE_LIST_ITEM,
+        matchArr[2],
+        { checked: matchArr[1] !== " " }
       );
     }
   }
-  let matchArr = line.match(/^[*-] (.*)$/);
-  if (matchArr) {
-    return changeCurrentBlockType(
-      editorState,
-      "unordered-list-item",
-      matchArr[1]
-    );
-  }
-  matchArr = line.match(/^[\d]\. (.*)$/);
-  if (matchArr) {
-    return changeCurrentBlockType(
-      editorState,
-      "ordered-list-item",
-      matchArr[1]
-    );
-  }
-  matchArr = line.match(/^> (.*)$/);
-  if (matchArr) {
-    return changeCurrentBlockType(editorState, "blockquote", matchArr[1]);
-  }
-  matchArr = line.match(/^\[([x ])] (.*)$/i);
-  if (matchArr && blockType === "unordered-list-item") {
-    return changeCurrentBlockType(
-      editorState,
-      CHECKABLE_LIST_ITEM,
-      matchArr[2],
-      { checked: matchArr[1] !== " " }
-    );
-  }
+
   return editorState;
 };
 


### PR DESCRIPTION
First off, love the plugin and the amount of work put into this fork.

When using this in my own project, I found it odd that shortcuts still apply if the block type is already a styled one. For example, typing "-  " inserts a list item and then if I type "# ", the list item is removed and replaced with a header.

Note that I'm pretty new to working with Draft, so I'd appreciate an extra close look at this.