### PR TITLE
Whitelist markdown features via `config.features`

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,61 @@ const languages = {
 const markdownPlugin = createMarkdownPlugin({ languages })
 ```
 
+### `features`
+A list of enabled features, by default all features are turned on.
+
+```js
+features = {
+  block: Array<string>,
+  inline: Array<string>,
+}
+```
+
+````
+#### Example
+
+```
+// this will only enable BOLD for inline and CODE
+// as well as header-one for blocks
+const features = {
+  inline: ['BOLD'],
+  block: ['CODE', 'header-one'],
+}
+const plugin = createMarkdownPlugin({ features })
+```
+
+*Available Inline features*:
+
+```js
+[
+  'BOLD',
+  'ITALIC',
+  'CODE',
+  'STRIKETHROUGH',
+  'LINK',
+  'IMAGE'
+]
+```
+
+*Available Block features*:
+
+```js
+[
+  'CODE',
+  'header-one',
+  'header-two',
+  'header-three',
+  'header-four',
+  'header-five',
+  'header-six',
+  'ordered-list-item',
+  'unordered-list-item',
+  CHECKABLE_LIST_ITEM,
+  'blockquote',
+]
+```
+
+
 ## Usage
 
 ```js

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ const plugin = createMarkdownPlugin({ features })
 *Available Block features*:
 
 ```js
+import { CHECKABLE_LIST_ITEM } from "draft-js-checkable-list-item"
 [
   'CODE',
   'header-one',
@@ -118,6 +119,8 @@ const plugin = createMarkdownPlugin({ features })
   'header-six',
   'ordered-list-item',
   'unordered-list-item',
+  // CHECKABLE_LIST_ITEM is a constant from 'draft-js-checkable-list-item'
+  // see import statementabove
   CHECKABLE_LIST_ITEM,
   'blockquote',
 ]

--- a/package.json
+++ b/package.json
@@ -95,8 +95,7 @@
   "peerDependencies": {
     "draft-js-plugins-editor": "~2.0.0-rc.1 || 2.0.0-rc2 || 2.0.0-rc1 || 2.0.0-beta12",
     "react": "^15.0.0",
-    "react-dom": "^15.0.0",
-    "react-portal": "^4.1.4"
+    "react-dom": "^15.0.0"
   },
   "contributors": [
     "Atsushi Nagase <a@ngs.io>"

--- a/src/__test__/plugin.test.js
+++ b/src/__test__/plugin.test.js
@@ -4,6 +4,8 @@ import {
   CheckableListItemUtils,
 } from "draft-js-checkable-list-item";
 
+import { defaultInlineWhitelist, defaultBlockWhitelist } from "../constants";
+
 import { Map, List } from "immutable";
 import createMarkdownPlugin from "../";
 
@@ -451,12 +453,7 @@ describe("draft-js-markdown-plugin", () => {
             ],
           };
         });
-        [
-          "handleBlockType",
-          "handleImage",
-          "handleLink",
-          "handleInlineStyle",
-        ].forEach(modifier => {
+        ["handleImage", "handleLink"].forEach(modifier => {
           describe(modifier, () => {
             beforeEach(() => {
               createMarkdownPlugin.__Rewire__(modifier, modifierSpy); // eslint-disable-line no-underscore-dangle
@@ -464,6 +461,36 @@ describe("draft-js-markdown-plugin", () => {
             it("returns handled", () => {
               expect(subject()).toBe("handled");
               expect(modifierSpy).toHaveBeenCalledWith(currentEditorState, " ");
+            });
+          });
+        });
+        ["handleBlockType"].forEach(modifier => {
+          describe(modifier, () => {
+            beforeEach(() => {
+              createMarkdownPlugin.__Rewire__(modifier, modifierSpy); // eslint-disable-line no-underscore-dangle
+            });
+            it("returns handled", () => {
+              expect(subject()).toBe("handled");
+              expect(modifierSpy).toHaveBeenCalledWith(
+                defaultBlockWhitelist,
+                currentEditorState,
+                " "
+              );
+            });
+          });
+        });
+        ["handleInlineStyle"].forEach(modifier => {
+          describe(modifier, () => {
+            beforeEach(() => {
+              createMarkdownPlugin.__Rewire__(modifier, modifierSpy); // eslint-disable-line no-underscore-dangle
+            });
+            it("returns handled", () => {
+              expect(subject()).toBe("handled");
+              expect(modifierSpy).toHaveBeenCalledWith(
+                defaultInlineWhitelist,
+                currentEditorState,
+                " "
+              );
             });
           });
         });

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,5 @@
+import { CHECKABLE_LIST_ITEM } from "draft-js-checkable-list-item";
+
 export const CODE_BLOCK_REGEX = /^```([\w-]+)?\s*$/;
 
 export const inlineMatchers = {
@@ -8,3 +10,26 @@ export const inlineMatchers = {
 };
 
 export const CODE_BLOCK_TYPE = "code-block";
+
+export const defaultInlineWhitelist = [
+  "BOLD",
+  "ITALIC",
+  "CODE",
+  "STRIKETHROUGH",
+  "LINK",
+  "IMAGE",
+];
+
+export const defaultBlockWhitelist = [
+  "CODE",
+  "header-one",
+  "header-two",
+  "header-three",
+  "header-four",
+  "header-five",
+  "header-six",
+  "ordered-list-item",
+  "unordered-list-item",
+  CHECKABLE_LIST_ITEM,
+  "blockquote",
+];

--- a/src/modifiers/__test__/handleBlockType-test.js
+++ b/src/modifiers/__test__/handleBlockType-test.js
@@ -1,5 +1,6 @@
 import Draft, { EditorState, SelectionState } from "draft-js";
 import handleBlockType from "../handleBlockType";
+import { defaultBlockWhitelist } from "../../constants";
 
 describe("handleBlockType", () => {
   describe("no markup", () => {
@@ -31,7 +32,11 @@ describe("handleBlockType", () => {
       selection
     );
     it("does not convert block type", () => {
-      const newEditorState = handleBlockType(editorState, " ");
+      const newEditorState = handleBlockType(
+        defaultBlockWhitelist,
+        editorState,
+        " "
+      );
       expect(newEditorState).toEqual(editorState);
       expect(Draft.convertToRaw(newEditorState.getCurrentContent())).toEqual(
         rawContentState
@@ -69,7 +74,11 @@ describe("handleBlockType", () => {
     );
 
     it("does not convert block type", () => {
-      const newEditorState = handleBlockType(editorState, " ");
+      const newEditorState = handleBlockType(
+        defaultBlockWhitelist,
+        editorState,
+        " "
+      );
       expect(newEditorState).toEqual(editorState);
       expect(Draft.convertToRaw(newEditorState.getCurrentContent())).toEqual(
         rawContentState
@@ -549,7 +558,11 @@ describe("handleBlockType", () => {
         selection
       );
       it("converts block type", () => {
-        const newEditorState = handleBlockType(editorState, character);
+        const newEditorState = handleBlockType(
+          defaultBlockWhitelist,
+          editorState,
+          character
+        );
         expect(newEditorState).not.toEqual(editorState);
         expect(Draft.convertToRaw(newEditorState.getCurrentContent())).toEqual(
           after

--- a/src/modifiers/__test__/handleInlineStyle-test.js
+++ b/src/modifiers/__test__/handleInlineStyle-test.js
@@ -2,6 +2,7 @@
 
 import Draft, { EditorState, SelectionState } from "draft-js";
 import handleInlineStyle from "../handleInlineStyle";
+import { defaultInlineWhitelist } from "../../constants";
 
 describe("handleInlineStyle", () => {
   describe("no markup", () => {
@@ -33,7 +34,11 @@ describe("handleInlineStyle", () => {
       selection
     );
     it("does not convert block type", () => {
-      const newEditorState = handleInlineStyle(editorState, " ");
+      const newEditorState = handleInlineStyle(
+        defaultInlineWhitelist,
+        editorState,
+        " "
+      );
       expect(newEditorState).toEqual(editorState);
       expect(Draft.convertToRaw(newEditorState.getCurrentContent())).toEqual(
         rawContentState
@@ -540,7 +545,11 @@ describe("handleInlineStyle", () => {
       );
 
       it("does not convert markdown to style or block type if selection is at the wrong place", () => {
-        const newEditorState = handleInlineStyle(sameEditorState, character);
+        const newEditorState = handleInlineStyle(
+          defaultInlineWhitelist,
+          sameEditorState,
+          character
+        );
         expect(newEditorState).toEqual(sameEditorState);
         expect(Draft.convertToRaw(newEditorState.getCurrentContent())).toEqual(
           before
@@ -548,7 +557,11 @@ describe("handleInlineStyle", () => {
       });
 
       it("converts markdown to style or block type", () => {
-        const newEditorState = handleInlineStyle(editorState, character);
+        const newEditorState = handleInlineStyle(
+          defaultInlineWhitelist,
+          editorState,
+          character
+        );
         expect(newEditorState).not.toEqual(editorState);
         expect(Draft.convertToRaw(newEditorState.getCurrentContent())).toEqual(
           after

--- a/src/modifiers/handleInlineStyle.js
+++ b/src/modifiers/handleInlineStyle.js
@@ -1,7 +1,7 @@
 import changeCurrentInlineStyle from "./changeCurrentInlineStyle";
 import { inlineMatchers } from "../constants";
 
-const handleInlineStyle = (editorState, character) => {
+const handleInlineStyle = (whitelist, editorState, character) => {
   const selection = editorState.getSelection();
   const key = editorState.getSelection().getStartKey();
   const text = editorState
@@ -15,25 +15,27 @@ const handleInlineStyle = (editorState, character) => {
 
   var i = 0;
 
-  Object.keys(inlineMatchers).some(k => {
-    inlineMatchers[k].some(re => {
-      let matchArr;
-      do {
-        matchArr = re.exec(line);
-        if (matchArr) {
-          newEditorState = changeCurrentInlineStyle(
-            newEditorState,
-            matchArr,
-            k,
-            character
-          );
-        }
-        i++;
-      } while (matchArr);
+  Object.keys(inlineMatchers)
+    .filter(matcher => whitelist.includes(matcher))
+    .some(k => {
+      inlineMatchers[k].some(re => {
+        let matchArr;
+        do {
+          matchArr = re.exec(line);
+          if (matchArr) {
+            newEditorState = changeCurrentInlineStyle(
+              newEditorState,
+              matchArr,
+              k,
+              character
+            );
+          }
+          i++;
+        } while (matchArr);
+        return newEditorState !== editorState;
+      });
       return newEditorState !== editorState;
     });
-    return newEditorState !== editorState;
-  });
   return newEditorState;
 };
 


### PR DESCRIPTION
- [x] whitelist block features
- [x] whitelist inline features
- [x] update tests
- [x] update readme to document whitelisted features

fixes #21

Example:

```js
// this will only enable BOLD for inline and CODE
// as well as header-one for blocks
const features = {
  inline: ['BOLD'],
  block: ['CODE', 'header-one'],
}
const plugin = createMarkdownPlugin({ features })
```