### PR TITLE
fix: only insert empty block for headers and blockquote when at end of line

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -122,8 +122,11 @@ function checkReturnForState(config, editorState, ev) {
   let newEditorState = editorState;
   const contentState = editorState.getCurrentContent();
   const selection = editorState.getSelection();
+  const isCollapsed = selection.isCollapsed();
   const key = selection.getStartKey();
+  const endOffset = selection.getEndOffset();
   const currentBlock = contentState.getBlockForKey(key);
+  const blockLength = currentBlock.getLength();
   const type = currentBlock.getType();
   const text = currentBlock.getText();
 
@@ -131,14 +134,16 @@ function checkReturnForState(config, editorState, ev) {
     newEditorState = leaveList(editorState);
   }
 
+  const modifierKeyPressed =
+    ev.ctrlKey || ev.shiftKey || ev.metaKey || ev.altKey;
+  const isAtEndOfLine = endOffset === blockLength;
+  const atEndOfHeader = /^header-/.test(type) && isAtEndOfLine;
+  const atEndOfBlockQuote = type === "blockquote" && isAtEndOfLine;
+
   if (
     newEditorState === editorState &&
-    (ev.ctrlKey ||
-      ev.shiftKey ||
-      ev.metaKey ||
-      ev.altKey ||
-      /^header-/.test(type) ||
-      type === "blockquote")
+    isCollapsed &&
+    (modifierKeyPressed || atEndOfHeader || atEndOfBlockQuote)
   ) {
     // transform markdown (if we aren't in a codeblock that is)
     if (!inCodeBlock(editorState)) {


### PR DESCRIPTION
The last PR went so well, I thought I'd keep going 👍
I found it odd when using this plugin that pressing enter at any time when within a header or blockquote block adds a new line and jumps to it. This PR ensures that the user is at the end of the line before that happens.

**Before**
\#\# He[CURSOR]ader
pressing enter becomes...
\#\# Header
[CURSOR]

\> Blockquo[CURSOR]te
pressing enter becomes...
\> Blockquote
[CURSOR]

**After**
\#\# He[CURSOR]ader
pressing enter becomes...
\#\# He
\#\# [CURSOR]ader

\> Blockquo[CURSOR]te
pressing enter becomes...
\> Blockquo
\> [CURSOR]te

I personally think this is a more intuitive behavior.

I based my knowledge of testing if we're at the end of the line from:
- https://github.com/facebook/draft-js/blob/4c4465f6c05b6dbb9eb769f98e659f917bbdc0f6/src/component/handlers/edit/commands/keyCommandMoveSelectionToEndOfBlock.js
- https://github.com/facebook/draft-js/blob/master/docs/APIReference-SelectionState.md#getendoffset