### PR TITLE
Fix code block exit with ```

### DIFF
--- a/src/__test__/plugin.test.js
+++ b/src/__test__/plugin.test.js
@@ -17,6 +17,7 @@ describe("draft-js-markdown-plugin", () => {
     createMarkdownPlugin.__ResetDependency__("handleInlineStyle");
     createMarkdownPlugin.__ResetDependency__("handleNewCodeBlock");
     createMarkdownPlugin.__ResetDependency__("insertEmptyBlock");
+    createMarkdownPlugin.__ResetDependency__("splitBlockAndChange");
     createMarkdownPlugin.__ResetDependency__("handleLink");
     createMarkdownPlugin.__ResetDependency__("handleImage");
     createMarkdownPlugin.__ResetDependency__("leaveList");
@@ -268,7 +269,10 @@ describe("draft-js-markdown-plugin", () => {
           describe(`on ${type}`, () => {
             const text = "Hello";
             beforeEach(() => {
-              createMarkdownPlugin.__Rewire__("insertEmptyBlock", modifierSpy); // eslint-disable-line no-underscore-dangle
+              createMarkdownPlugin.__Rewire__(
+                "splitBlockAndChange",
+                modifierSpy
+              ); // eslint-disable-line no-underscore-dangle
               currentRawContentState = {
                 entityMap: {},
                 blocks: [
@@ -287,6 +291,10 @@ describe("draft-js-markdown-plugin", () => {
 
             describe("at the end of line", () => {
               beforeEach(() => {
+                createMarkdownPlugin.__Rewire__(
+                  "insertEmptyBlock",
+                  modifierSpy
+                ); // eslint-disable-line no-underscore-dangle
                 currentSelectionState = currentEditorState
                   .getSelection()
                   .merge({
@@ -308,14 +316,15 @@ describe("draft-js-markdown-plugin", () => {
               });
             });
             describe("when not at the end of the line", () => {
-              it("does not handle", () => {
-                expect(subject()).toBe("not-handled");
-                expect(modifierSpy).not.toHaveBeenCalled();
-                expect(store.setEditorState).not.toHaveBeenCalled();
+              it("splits and resets block", () => {
+                expect(subject()).toBe("handled");
+                expect(modifierSpy).toHaveBeenCalled();
+                expect(store.setEditorState).toHaveBeenCalled();
               });
             });
           });
         });
+
         ["ctrlKey", "shiftKey", "metaKey", "altKey"].forEach(key => {
           describe(`${key} is pressed`, () => {
             beforeEach(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -174,7 +174,7 @@ function checkReturnForState(config, editorState, ev) {
       newEditorState = changeCurrentBlockType(
         newEditorState,
         type,
-        text.replace(/\n```\s*$/, "")
+        text.replace(/```\s*$/, "")
       );
       newEditorState = insertEmptyBlock(newEditorState);
     } else {

--- a/src/modifiers/splitBlockAndChange.js
+++ b/src/modifiers/splitBlockAndChange.js
@@ -1,0 +1,25 @@
+import { EditorState, Modifier } from "draft-js";
+
+const splitBlockAndChange = (
+  editorState,
+  type = "unstyled",
+  blockMetadata = {}
+) => {
+  let currentContent = editorState.getCurrentContent();
+  let selection = editorState.getSelection();
+  currentContent = Modifier.splitBlock(currentContent, selection);
+  selection = currentContent.getSelectionAfter();
+  const key = selection.getStartKey();
+  const blockMap = currentContent.getBlockMap();
+  const block = blockMap.get(key);
+  const data = block.getData().merge(blockMetadata);
+  const newBlock = block.merge({ type, data });
+  const newContentState = currentContent.merge({
+    blockMap: blockMap.set(key, newBlock),
+    selectionAfter: selection,
+  });
+
+  return EditorState.push(editorState, newContentState, "split-block");
+};
+
+export default splitBlockAndChange;


### PR DESCRIPTION
properly replaces backticks on both empty and non-empty lines

fixes #51 