### PR TITLE
fix modifier interaction

### DIFF
--- a/src/__test__/plugin.test.js
+++ b/src/__test__/plugin.test.js
@@ -333,7 +333,6 @@ describe("draft-js-markdown-plugin", () => {
               event = new window.KeyboardEvent("keydown", props);
             });
             it("inserts new empty block", () => {
-              createMarkdownPlugin.__Rewire__("insertEmptyBlock", modifierSpy); // eslint-disable-line no-underscore-dangle
               const text = "Hello";
               currentRawContentState = {
                 entityMap: {},
@@ -349,9 +348,8 @@ describe("draft-js-markdown-plugin", () => {
                   },
                 ],
               };
-              expect(subject()).toBe("handled");
-              expect(modifierSpy).toHaveBeenCalledTimes(1);
-              expect(store.setEditorState).toHaveBeenCalledWith(newEditorState);
+              expect(subject()).toBe("not-handled");
+              expect(store.setEditorState).not.toHaveBeenCalled();
             });
           });
         });

--- a/src/index.js
+++ b/src/index.js
@@ -137,9 +137,6 @@ function checkReturnForState(config, editorState, ev) {
 
   const isHeader = /^header-/.test(type);
   const isBlockQuote = type === "blockquote";
-
-  const modifierKeyPressed =
-    ev.ctrlKey || ev.shiftKey || ev.metaKey || ev.altKey;
   const isAtEndOfLine = endOffset === blockLength;
   const atEndOfHeader = isHeader && isAtEndOfLine;
   const atEndOfBlockQuote = isBlockQuote && isAtEndOfLine;
@@ -147,7 +144,7 @@ function checkReturnForState(config, editorState, ev) {
   if (
     newEditorState === editorState &&
     isCollapsed &&
-    (modifierKeyPressed || atEndOfHeader || atEndOfBlockQuote)
+    (atEndOfHeader || atEndOfBlockQuote)
   ) {
     // transform markdown (if we aren't in a codeblock that is)
     if (!inCodeBlock(editorState)) {


### PR DESCRIPTION
fixes #52 
This disables the current behaviour on return when modifiers are used.

Afaik originally the intention was to transform markdown upon hitting `modifier + return` but since we now transform markdown upon return anyway it gets handled twice, this fixes this.