### PR TITLE
Create new code block on space

### DIFF
--- a/src/__test__/plugin.test.js
+++ b/src/__test__/plugin.test.js
@@ -613,6 +613,27 @@ describe("draft-js-markdown-plugin", () => {
             expect(subject()).toBe("not-handled");
           });
         });
+        it("handles new code block on space", () => {
+          createMarkdownPlugin.__Rewire__("handleNewCodeBlock", modifierSpy); // eslint-disable-line no-underscore-dangle
+          currentRawContentState = {
+            entityMap: {},
+            blocks: [
+              {
+                key: "item1",
+                text: "```",
+                type: "unstyled",
+                depth: 0,
+                inlineStyleRanges: [],
+                entityRanges: [],
+                data: {},
+              },
+            ],
+          };
+          character = " ";
+          expect(subject()).toBe("handled");
+          expect(modifierSpy).toHaveBeenCalledTimes(1);
+          expect(store.setEditorState).toHaveBeenCalledWith(newEditorState);
+        });
       });
       describe("handlePastedText", () => {
         let pastedText;

--- a/src/index.js
+++ b/src/index.js
@@ -109,6 +109,19 @@ function checkCharacterForState(config, editorState, character) {
   ) {
     newEditorState = handleLink(editorState, character);
   }
+  if (
+    newEditorState === editorState &&
+    config.features.block.includes("CODE")
+  ) {
+    const contentState = editorState.getCurrentContent();
+    const selection = editorState.getSelection();
+    const key = selection.getStartKey();
+    const currentBlock = contentState.getBlockForKey(key);
+    const text = currentBlock.getText();
+    const type = currentBlock.getType();
+    if (type !== "code-block" && CODE_BLOCK_REGEX.test(text))
+      newEditorState = handleNewCodeBlock(editorState);
+  }
   if (editorState === newEditorState) {
     newEditorState = handleInlineStyle(
       config.features.inline,


### PR DESCRIPTION
This means we don't require enter to create new code blocks, which solves a couple QoL issues. Ref withspectrum/spectrum#2854

/cc @brianlovin