### PR TITLE
fix #65: set both href and url properties in link data

### DIFF
--- a/src/modifiers/__test__/insertLink-test.js
+++ b/src/modifiers/__test__/insertLink-test.js
@@ -23,6 +23,7 @@ describe("insertLink", () => {
       0: {
         data: {
           href: "http://cultofthepartyparrot.com/parrots/aussieparrot.gif",
+          url: "http://cultofthepartyparrot.com/parrots/aussieparrot.gif",
           title: "party",
         },
         mutability: "MUTABLE",

--- a/src/modifiers/insertLink.js
+++ b/src/modifiers/insertLink.js
@@ -14,6 +14,7 @@ const insertLink = (editorState, matchArr) => {
   const nextContent = currentContent.createEntity("LINK", "MUTABLE", {
     href,
     title,
+    url: href,
   });
   const entityKey = nextContent.getLastCreatedEntityKey();
   let newContentState = Modifier.replaceText(


### PR DESCRIPTION
Most markdown parsers rely on links having a url property.