### PR TITLE
Trigger markdown on any character and change markdown implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,64 @@ A [DraftJS] plugin for supporting Markdown syntax shortcuts in DraftJS. This plu
 npm i --save draft-js-markdown-plugin
 ```
 
-## Options
-The `draft-js-markdown-plugin` is configurable. Just pass a config object. Here are the available options:
+## Usage
 
+```js
+import React, { Component } from 'react';
+import Editor from 'draft-js-plugins-editor';
+import createMarkdownPlugin from 'draft-js-markdown-plugin';
+import { EditorState } from 'draft-js';
+
+export default class DemoEditor extends Component {
+
+  state = {
+    editorState: EditorState.createEmpty(),
+    plugins: [createMarkdownPlugin()]
+  };
+
+  onChange = (editorState) => {
+    this.setState({
+      editorState,
+    });
+  };
+
+  render() {
+    return (
+      <Editor
+        editorState={this.state.editorState}
+        onChange={this.onChange}
+        plugins={this.state.plugins}
+      />
+    );
+  }
+}
+```
+
+### Add code block syntax highlighting
+
+Using the [`draft-js-prism-plugin`](https://github.com/withspectrum/draft-js-prism-plugin) you can easily add syntax highlighting support to your code blocks!
+
+```JS
+// Install prismjs and draft-js-prism-plugin
+import Prism from 'prismjs';
+import createPrismPlugin from 'draft-js-prism-plugin';
+
+class Editor extends Component {
+  state = {
+    plugins: [
+      // Add the Prism plugin to the plugins array 
+      createPrismPlugin({
+        prism: Prism
+      }),
+      createMarkdownPlugin()
+    ]
+  }
+}
+```
+
+## Options
+
+The `draft-js-markdown-plugin` is configurable. Just pass a config object. Here are the available options:
 
 ### `renderLanguageSelect`
 
@@ -150,61 +205,6 @@ const imagePlugin = createImagePlugin({
 const markdownPlugin = createMarkdownPlugin({ entityType });
 
 const editorPlugins = [focusPlugin, imagePlugin, markdownPlugin];
-```
-
-## Usage
-
-```js
-import React, { Component } from 'react';
-import Editor from 'draft-js-plugins-editor';
-import createMarkdownPlugin from 'draft-js-markdown-plugin';
-import { EditorState } from 'draft-js';
-
-export default class DemoEditor extends Component {
-
-  state = {
-    editorState: EditorState.createEmpty(),
-    plugins: [createMarkdownPlugin()]
-  };
-
-  onChange = (editorState) => {
-    this.setState({
-      editorState,
-    });
-  };
-
-  render() {
-    return (
-      <Editor
-        editorState={this.state.editorState}
-        onChange={this.onChange}
-        plugins={this.state.plugins}
-      />
-    );
-  }
-}
-```
-
-### Add code block syntax highlighting
-
-Using the [`draft-js-prism-plugin`](https://github.com/withspectrum/draft-js-prism-plugin) you can easily add syntax highlighting support to your code blocks!
-
-```JS
-// Install prismjs and draft-js-prism-plugin
-import Prism from 'prismjs';
-import createPrismPlugin from 'draft-js-prism-plugin';
-
-class Editor extends Component {
-  state = {
-    plugins: [
-      // Add the Prism plugin to the plugins array 
-      createPrismPlugin({
-        prism: Prism
-      }),
-      createMarkdownPlugin()
-    ]
-  }
-}
 ```
 
 ## Why fork the `markdown-shortcuts-plugin`?

--- a/src/__test__/plugin.test.js
+++ b/src/__test__/plugin.test.js
@@ -228,37 +228,6 @@ describe("draft-js-markdown-plugin", () => {
           expect(store.setEditorState).toHaveBeenCalledWith(newEditorState);
         });
 
-        it("adds list item and transforms markdown", () => {
-          // createMarkdownPlugin.__Rewire__("leaveList", modifierSpy); // eslint-disable-line no-underscore-dangle
-          currentRawContentState = {
-            entityMap: {},
-            blocks: [
-              {
-                key: "item1",
-                text: "**some bold text**",
-                type: "unordered-list-item",
-                depth: 0,
-                inlineStyleRanges: [],
-                entityRanges: [],
-                data: {},
-              },
-            ],
-          };
-          currentSelectionState = currentSelectionState.merge({
-            focusOffset: 18,
-            anchorOffset: 18,
-          });
-          expect(subject()).toBe("handled");
-          // expect(modifierSpy).toHaveBeenCalledTimes(1);
-          expect(store.setEditorState).toHaveBeenCalledTimes(1);
-          newEditorState = store.setEditorState.mock.calls[0][0];
-          const newRawContentState = Draft.convertToRaw(
-            newEditorState.getCurrentContent()
-          );
-          expect(newRawContentState.blocks.length).toBe(2);
-          expect(newEditorState.getCurrentInlineStyle().size).toBe(0);
-        });
-
         const emptyBlockTypes = [
           "blockquote",
           "header-one",

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,8 +3,8 @@ import { CHECKABLE_LIST_ITEM } from "draft-js-checkable-list-item";
 export const CODE_BLOCK_REGEX = /^```([\w-]+)?\s*$/;
 
 export const inlineMatchers = {
-  BOLD: [/\*\*(.+)\*\*$/g, /__(.+)__$/g],
-  ITALIC: [/\*(.+)\*$/g, /_(.+)_$/g],
+  BOLD: [/\*(.+)\*$/g],
+  ITALIC: [/_(.+)_$/g],
   CODE: [/`(.+)`$/g],
   STRIKETHROUGH: [/~~(.+)~~$/g],
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,8 +5,8 @@ export const CODE_BLOCK_REGEX = /^```([\w-]+)?\s*$/;
 export const inlineMatchers = {
   BOLD: [/\*(.+)\*$/g],
   ITALIC: [/_(.+)_$/g],
-  CODE: [/`(.+)`$/g],
-  STRIKETHROUGH: [/~~(.+)~~$/g],
+  CODE: [/`([^`]+)`$/g],
+  STRIKETHROUGH: [/~(.+)~$/g],
 };
 
 export const CODE_BLOCK_TYPE = "code-block";

--- a/src/index.js
+++ b/src/index.js
@@ -341,10 +341,6 @@ const createMarkdownPlugin = (_config = {}) => {
       return "not-handled";
     },
     handleBeforeInput(character, editorState, { setEditorState }) {
-      if (character !== " ") {
-        return "not-handled";
-      }
-
       // If we're in a code block - don't transform markdown
       if (inCodeBlock(editorState)) return "not-handled";
 

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ import insertText from "./modifiers/insertText";
 import changeCurrentBlockType from "./modifiers/changeCurrentBlockType";
 import createLinkDecorator from "./decorators/link";
 import createImageDecorator from "./decorators/image";
-import { replaceText } from "./utils";
+import { replaceText, getCurrentLine } from "./utils";
 import {
   CODE_BLOCK_REGEX,
   CODE_BLOCK_TYPE,
@@ -57,7 +57,7 @@ const defaultLanguages = {
   swift: "Swift",
 };
 
-const INLINE_STYLE_CHARACTERS = [" ", "*", "_"];
+const INLINE_STYLE_CHARACTERS = ["*", "_", "`", "~"];
 
 const defaultRenderSelect = ({ options, onChange, selectedValue }) => (
   <select value={selectedValue} onChange={onChange}>
@@ -346,6 +346,10 @@ const createMarkdownPlugin = (_config = {}) => {
 
       // If we're in a link - don't transform markdown
       if (inLink(editorState)) return "not-handled";
+
+      // Don't let users type two spaces after another
+      if (character === " " && getCurrentLine(editorState).slice(-1) === " ")
+        return "handled";
 
       const newEditorState = checkCharacterForState(
         config,

--- a/src/modifiers/__test__/handleInlineStyle-test.js
+++ b/src/modifiers/__test__/handleInlineStyle-test.js
@@ -54,7 +54,7 @@ describe("handleInlineStyle", () => {
         blocks: [
           {
             key: "item1",
-            text: "`h~~el*lo _inline~~_* style",
+            text: "`h~el*lo _inline~_* style",
             type: "unstyled",
             depth: 0,
             inlineStyleRanges: [],
@@ -100,9 +100,9 @@ describe("handleInlineStyle", () => {
       },
       selection: new SelectionState({
         anchorKey: "item1",
-        anchorOffset: 21,
+        anchorOffset: 19,
         focusKey: "item1",
-        focusOffset: 21,
+        focusOffset: 19,
         isBackward: false,
         hasFocus: true,
       }),
@@ -351,7 +351,7 @@ describe("handleInlineStyle", () => {
         blocks: [
           {
             key: "item1",
-            text: "hello ~~inline~ style",
+            text: "hello ~inline style",
             type: "unstyled",
             depth: 0,
             inlineStyleRanges: [],
@@ -382,9 +382,9 @@ describe("handleInlineStyle", () => {
       },
       selection: new SelectionState({
         anchorKey: "item1",
-        anchorOffset: 15,
+        anchorOffset: 13,
         focusKey: "item1",
-        focusOffset: 15,
+        focusOffset: 13,
         isBackward: false,
         hasFocus: true,
       }),

--- a/src/modifiers/__test__/handleInlineStyle-test.js
+++ b/src/modifiers/__test__/handleInlineStyle-test.js
@@ -53,7 +53,7 @@ describe("handleInlineStyle", () => {
         blocks: [
           {
             key: "item1",
-            text: "`h~~el**lo *inline~~***` style",
+            text: "`h~~el*lo _inline~~_*` style",
             type: "unstyled",
             depth: 0,
             inlineStyleRanges: [],
@@ -99,9 +99,9 @@ describe("handleInlineStyle", () => {
       },
       selection: new SelectionState({
         anchorKey: "item1",
-        anchorOffset: 24,
+        anchorOffset: 22,
         focusKey: "item1",
-        focusOffset: 24,
+        focusOffset: 22,
         isBackward: false,
         hasFocus: true,
       }),
@@ -113,7 +113,7 @@ describe("handleInlineStyle", () => {
         blocks: [
           {
             key: "item1",
-            text: "hello **inline** style",
+            text: "hello *inline* style",
             type: "unstyled",
             depth: 0,
             inlineStyleRanges: [],
@@ -144,9 +144,9 @@ describe("handleInlineStyle", () => {
       },
       selection: new SelectionState({
         anchorKey: "item1",
-        anchorOffset: 16,
+        anchorOffset: 14,
         focusKey: "item1",
-        focusOffset: 16,
+        focusOffset: 14,
         isBackward: false,
         hasFocus: true,
       }),
@@ -191,94 +191,6 @@ describe("handleInlineStyle", () => {
         anchorOffset: 16,
         focusKey: "item1",
         focusOffset: 16,
-        isBackward: false,
-        hasFocus: true,
-      }),
-    },
-    "converts to bold with underscores": {
-      before: {
-        entityMap: {},
-        blocks: [
-          {
-            key: "item1",
-            text: "hello __inline__ style",
-            type: "unstyled",
-            depth: 0,
-            inlineStyleRanges: [],
-            entityRanges: [],
-            data: {},
-          },
-        ],
-      },
-      after: {
-        entityMap: {},
-        blocks: [
-          {
-            key: "item1",
-            text: "hello inline  style",
-            type: "unstyled",
-            depth: 0,
-            inlineStyleRanges: [
-              {
-                length: 6,
-                offset: 6,
-                style: "BOLD",
-              },
-            ],
-            entityRanges: [],
-            data: {},
-          },
-        ],
-      },
-      selection: new SelectionState({
-        anchorKey: "item1",
-        anchorOffset: 16,
-        focusKey: "item1",
-        focusOffset: 16,
-        isBackward: false,
-        hasFocus: true,
-      }),
-    },
-    "converts to italic with astarisk": {
-      before: {
-        entityMap: {},
-        blocks: [
-          {
-            key: "item1",
-            text: "hello *inline* style",
-            type: "unstyled",
-            depth: 0,
-            inlineStyleRanges: [],
-            entityRanges: [],
-            data: {},
-          },
-        ],
-      },
-      after: {
-        entityMap: {},
-        blocks: [
-          {
-            key: "item1",
-            text: "hello inline  style",
-            type: "unstyled",
-            depth: 0,
-            inlineStyleRanges: [
-              {
-                length: 6,
-                offset: 6,
-                style: "ITALIC",
-              },
-            ],
-            entityRanges: [],
-            data: {},
-          },
-        ],
-      },
-      selection: new SelectionState({
-        anchorKey: "item1",
-        anchorOffset: 14,
-        focusKey: "item1",
-        focusOffset: 14,
         isBackward: false,
         hasFocus: true,
       }),
@@ -333,7 +245,7 @@ describe("handleInlineStyle", () => {
         blocks: [
           {
             key: "item1",
-            text: "hello **inline** style",
+            text: "hello *inline* style",
             type: "unstyled",
             depth: 0,
             inlineStyleRanges: [
@@ -375,9 +287,9 @@ describe("handleInlineStyle", () => {
       },
       selection: new SelectionState({
         anchorKey: "item1",
-        anchorOffset: 16,
+        anchorOffset: 14,
         focusKey: "item1",
-        focusOffset: 16,
+        focusOffset: 14,
         isBackward: false,
         hasFocus: true,
       }),
@@ -473,62 +385,6 @@ describe("handleInlineStyle", () => {
 
     // combine tests
 
-    "combines to italic and bold with underscores": {
-      before: {
-        entityMap: {},
-        blocks: [
-          {
-            key: "item1",
-            text: "hello __inline__ style",
-            type: "unstyled",
-            depth: 0,
-            inlineStyleRanges: [
-              {
-                length: 4,
-                offset: 5,
-                style: "ITALIC",
-              },
-            ],
-            entityRanges: [],
-            data: {},
-          },
-        ],
-      },
-      after: {
-        entityMap: {},
-        blocks: [
-          {
-            key: "item1",
-            text: "hello inline  style",
-            type: "unstyled",
-            depth: 0,
-            inlineStyleRanges: [
-              {
-                length: 2,
-                offset: 5,
-                style: "ITALIC",
-              },
-              {
-                length: 6,
-                offset: 6,
-                style: "BOLD",
-              },
-            ],
-            entityRanges: [],
-            data: {},
-          },
-        ],
-      },
-      selection: new SelectionState({
-        anchorKey: "item1",
-        anchorOffset: 16,
-        focusKey: "item1",
-        focusOffset: 16,
-        isBackward: false,
-        hasFocus: true,
-      }),
-    },
-
     "combines to bold and italic with underscores": {
       before: {
         entityMap: {},
@@ -610,10 +466,10 @@ describe("handleInlineStyle", () => {
           sameEditorState,
           character
         );
-        expect(newEditorState).toEqual(sameEditorState);
         expect(Draft.convertToRaw(newEditorState.getCurrentContent())).toEqual(
           before
         );
+        expect(newEditorState).toEqual(sameEditorState);
       });
 
       it("converts markdown to style or block type", () => {
@@ -622,10 +478,10 @@ describe("handleInlineStyle", () => {
           editorState,
           character
         );
-        expect(newEditorState).not.toEqual(editorState);
         expect(Draft.convertToRaw(newEditorState.getCurrentContent())).toEqual(
           after
         );
+        expect(newEditorState).not.toEqual(editorState);
       });
     });
   });

--- a/src/modifiers/__test__/handleInlineStyle-test.js
+++ b/src/modifiers/__test__/handleInlineStyle-test.js
@@ -48,12 +48,13 @@ describe("handleInlineStyle", () => {
 
   const testCases = {
     "converts a mix of code, bold and italic and strikethrough in one go": {
+      character: "`",
       before: {
         entityMap: {},
         blocks: [
           {
             key: "item1",
-            text: "`h~~el*lo _inline~~_*` style",
+            text: "`h~~el*lo _inline~~_* style",
             type: "unstyled",
             depth: 0,
             inlineStyleRanges: [],
@@ -99,21 +100,22 @@ describe("handleInlineStyle", () => {
       },
       selection: new SelectionState({
         anchorKey: "item1",
-        anchorOffset: 22,
+        anchorOffset: 21,
         focusKey: "item1",
-        focusOffset: 22,
+        focusOffset: 21,
         isBackward: false,
         hasFocus: true,
       }),
     },
 
     "converts to bold with astarisks": {
+      character: "*",
       before: {
         entityMap: {},
         blocks: [
           {
             key: "item1",
-            text: "hello *inline* style",
+            text: "hello *inline style",
             type: "unstyled",
             depth: 0,
             inlineStyleRanges: [],
@@ -144,20 +146,21 @@ describe("handleInlineStyle", () => {
       },
       selection: new SelectionState({
         anchorKey: "item1",
-        anchorOffset: 14,
+        anchorOffset: 13,
         focusKey: "item1",
-        focusOffset: 14,
+        focusOffset: 13,
         isBackward: false,
         hasFocus: true,
       }),
     },
     "converts semicolons to bold with astarisks": {
+      character: "*",
       before: {
         entityMap: {},
         blocks: [
           {
             key: "item1",
-            text: "hello **TL;DR:** style",
+            text: "hello *TL;DR: style",
             type: "unstyled",
             depth: 0,
             inlineStyleRanges: [],
@@ -188,20 +191,21 @@ describe("handleInlineStyle", () => {
       },
       selection: new SelectionState({
         anchorKey: "item1",
-        anchorOffset: 16,
+        anchorOffset: 13,
         focusKey: "item1",
-        focusOffset: 16,
+        focusOffset: 13,
         isBackward: false,
         hasFocus: true,
       }),
     },
     "converts to italic with underscore": {
+      character: "_",
       before: {
         entityMap: {},
         blocks: [
           {
             key: "item1",
-            text: "hello _inline_ style",
+            text: "hello _inline style",
             type: "unstyled",
             depth: 0,
             inlineStyleRanges: [],
@@ -232,20 +236,21 @@ describe("handleInlineStyle", () => {
       },
       selection: new SelectionState({
         anchorKey: "item1",
-        anchorOffset: 14,
+        anchorOffset: 13,
         focusKey: "item1",
-        focusOffset: 14,
+        focusOffset: 13,
         isBackward: false,
         hasFocus: true,
       }),
     },
     "combines to italic and bold with astarisks": {
+      character: "*",
       before: {
         entityMap: {},
         blocks: [
           {
             key: "item1",
-            text: "hello *inline* style",
+            text: "hello *inline style",
             type: "unstyled",
             depth: 0,
             inlineStyleRanges: [
@@ -287,20 +292,21 @@ describe("handleInlineStyle", () => {
       },
       selection: new SelectionState({
         anchorKey: "item1",
-        anchorOffset: 14,
+        anchorOffset: 13,
         focusKey: "item1",
-        focusOffset: 14,
+        focusOffset: 13,
         isBackward: false,
         hasFocus: true,
       }),
     },
     "converts to code with backquote": {
+      character: "`",
       before: {
         entityMap: {},
         blocks: [
           {
             key: "item1",
-            text: "hello `inline` style",
+            text: "hello `inline style",
             type: "unstyled",
             depth: 0,
             inlineStyleRanges: [],
@@ -331,20 +337,21 @@ describe("handleInlineStyle", () => {
       },
       selection: new SelectionState({
         anchorKey: "item1",
-        anchorOffset: 14,
+        anchorOffset: 13,
         focusKey: "item1",
-        focusOffset: 14,
+        focusOffset: 13,
         isBackward: false,
         hasFocus: true,
       }),
     },
     "converts to strikethrough with tildes": {
+      character: "~",
       before: {
         entityMap: {},
         blocks: [
           {
             key: "item1",
-            text: "hello ~~inline~~ style",
+            text: "hello ~~inline~ style",
             type: "unstyled",
             depth: 0,
             inlineStyleRanges: [],
@@ -375,9 +382,9 @@ describe("handleInlineStyle", () => {
       },
       selection: new SelectionState({
         anchorKey: "item1",
-        anchorOffset: 16,
+        anchorOffset: 15,
         focusKey: "item1",
-        focusOffset: 16,
+        focusOffset: 15,
         isBackward: false,
         hasFocus: true,
       }),
@@ -386,12 +393,13 @@ describe("handleInlineStyle", () => {
     // combine tests
 
     "combines to bold and italic with underscores": {
+      character: "_",
       before: {
         entityMap: {},
         blocks: [
           {
             key: "item1",
-            text: "hello _inline_ style",
+            text: "hello _inline style",
             type: "unstyled",
             depth: 0,
             inlineStyleRanges: [
@@ -433,9 +441,9 @@ describe("handleInlineStyle", () => {
       },
       selection: new SelectionState({
         anchorKey: "item1",
-        anchorOffset: 14,
+        anchorOffset: 13,
         focusKey: "item1",
-        focusOffset: 14,
+        focusOffset: 13,
         isBackward: false,
         hasFocus: true,
       }),
@@ -444,7 +452,11 @@ describe("handleInlineStyle", () => {
   Object.keys(testCases).forEach(k => {
     describe(k, () => {
       const testCase = testCases[k];
-      const { before, after, selection, character = " " } = testCase;
+      const { before, after, selection, character } = testCase;
+      if (!character)
+        throw new Error(
+          "Invalid test case, needs to provide character option."
+        );
       const contentState = Draft.convertFromRaw(before);
       const editorState = EditorState.forceSelection(
         EditorState.createWithContent(contentState),

--- a/src/modifiers/handleInlineStyle.js
+++ b/src/modifiers/handleInlineStyle.js
@@ -1,6 +1,7 @@
 import changeCurrentInlineStyle from "./changeCurrentInlineStyle";
 import { EditorState, Modifier } from "draft-js";
 import { inlineMatchers } from "../constants";
+import insertText from "./insertText";
 
 const handleChange = (editorState, line, whitelist) => {
   let newEditorState = editorState;
@@ -37,12 +38,18 @@ const getLine = (editorState, anchorOffset) => {
     .slice(0, selection.getFocusOffset());
 };
 
-const handleInlineStyle = (whitelist, editorState, character) => {
+const handleInlineStyle = (
+  whitelist,
+  editorStateWithoutCharacter,
+  character
+) => {
+  const editorState = insertText(editorStateWithoutCharacter, character);
   let selection = editorState.getSelection();
   let line = getLine(editorState, selection.getAnchorOffset());
   let newEditorState = handleChange(editorState, line, whitelist);
   let lastEditorState = editorState;
 
+  // Recursively resolve markdown, e.g. _*text*_ should turn into both italic and bold
   while (newEditorState !== lastEditorState) {
     lastEditorState = newEditorState;
     line = getLine(newEditorState, selection.getAnchorOffset());
@@ -56,11 +63,7 @@ const handleInlineStyle = (whitelist, editorState, character) => {
     if (character === "\n") {
       newContentState = Modifier.splitBlock(newContentState, selection);
     } else {
-      newContentState = Modifier.insertText(
-        newContentState,
-        selection,
-        character
-      );
+      newContentState = Modifier.insertText(newContentState, selection, " ");
     }
 
     newEditorState = EditorState.push(
@@ -68,9 +71,11 @@ const handleInlineStyle = (whitelist, editorState, character) => {
       newContentState,
       "change-inline-style"
     );
+
+    return newEditorState;
   }
 
-  return newEditorState;
+  return editorStateWithoutCharacter;
 };
 
 export default handleInlineStyle;

--- a/src/modifiers/handleInlineStyle.js
+++ b/src/modifiers/handleInlineStyle.js
@@ -2,6 +2,7 @@ import changeCurrentInlineStyle from "./changeCurrentInlineStyle";
 import { EditorState, Modifier } from "draft-js";
 import { inlineMatchers } from "../constants";
 import insertText from "./insertText";
+import { getCurrentLine as getLine } from "../utils";
 
 const handleChange = (editorState, line, whitelist) => {
   let newEditorState = editorState;
@@ -27,17 +28,6 @@ const handleChange = (editorState, line, whitelist) => {
   return newEditorState;
 };
 
-const getLine = (editorState, anchorOffset) => {
-  const selection = editorState.getSelection().merge({ anchorOffset });
-  const key = editorState.getSelection().getStartKey();
-
-  return editorState
-    .getCurrentContent()
-    .getBlockForKey(key)
-    .getText()
-    .slice(0, selection.getFocusOffset());
-};
-
 const handleInlineStyle = (
   whitelist,
   editorStateWithoutCharacter,
@@ -45,14 +35,14 @@ const handleInlineStyle = (
 ) => {
   const editorState = insertText(editorStateWithoutCharacter, character);
   let selection = editorState.getSelection();
-  let line = getLine(editorState, selection.getAnchorOffset());
+  let line = getLine(editorState);
   let newEditorState = handleChange(editorState, line, whitelist);
   let lastEditorState = editorState;
 
   // Recursively resolve markdown, e.g. _*text*_ should turn into both italic and bold
   while (newEditorState !== lastEditorState) {
     lastEditorState = newEditorState;
-    line = getLine(newEditorState, selection.getAnchorOffset());
+    line = getLine(newEditorState);
     newEditorState = handleChange(newEditorState, line, whitelist);
   }
 

--- a/src/modifiers/insertText.js
+++ b/src/modifiers/insertText.js
@@ -3,6 +3,7 @@ import { EditorState, Modifier } from "draft-js";
 const insertText = (editorState, text) => {
   const selection = editorState.getSelection();
   const content = editorState.getCurrentContent();
+  if (!selection.isCollapsed()) return editorState;
   const newContentState = Modifier.insertText(
     content,
     selection,

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,17 @@
 import { Modifier, EditorState } from "draft-js";
 
+export const getCurrentLine = editorState => {
+  const { anchorOffset } = editorState.getSelection();
+  const selection = editorState.getSelection().merge({ anchorOffset });
+  const key = editorState.getSelection().getStartKey();
+
+  return editorState
+    .getCurrentContent()
+    .getBlockForKey(key)
+    .getText()
+    .slice(0, selection.getFocusOffset());
+};
+
 export function addText(editorState, bufferText) {
   const contentState = Modifier.insertText(
     editorState.getCurrentContent(),


### PR DESCRIPTION
**DEMO:  https://public-myglckweth.now.sh**

This PR makes it so that markdown is created when pressing the closing character of the markdown instance, not when pressing space which is a much nicer experience for the users.

Due to that, I had to change the markdown implementation to only allow a single way of doing things that doesn't conflict with each other:

- **bold** will be triggered by `*bold*`
- _italic_ will be triggered by `_italic_`
- ~~strikethrough~~ will be triggered by `~strikethrough~`

Nothing else should have changed.