### PR TITLE
force editor selection only if handling click when language select is…

### DIFF
--- a/src/components/Code/index.js
+++ b/src/components/Code/index.js
@@ -70,9 +70,18 @@ class CodeBlock extends PureComponent {
     const { setReadOnly } = this.props.blockProps;
     event.stopPropagation();
     setReadOnly(true);
+    this.setState({
+      isOpen: true,
+    });
   };
 
   onClickOutside = () => {
+    if (!this.state.isOpen) {
+      return;
+    }
+    this.setState({
+      isOpen: false,
+    });
     const {
       getEditorState,
       setReadOnly,


### PR DESCRIPTION
force editor selection only if handling click when language select is opened

When the editor does not take the whole page and renders together with other elements (in my case they are focusable inputs) it is impossible to focus anything else expect the editor

