### PR TITLE
Remove unnecessary outside click handling Code

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "draft-js": "^0.10.4",
     "draft-js-checkable-list-item": "^2.0.5",
     "draft-js-prism-plugin": "^0.1.1",
-    "immutable": "~3.7.4",
-    "react-click-outside": "^3.0.1"
+    "immutable": "~3.7.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-js-markdown-plugin",
-  "version": "2.0.2",
+  "version": "2.0.3-0",
   "description": "A DraftJS plugin for supporting Markdown syntax shortcuts, fork of draft-js-markdown-shortcuts-plugin",
   "main": "lib/index.js",
   "scripts": {

--- a/src/components/Code/index.js
+++ b/src/components/Code/index.js
@@ -18,10 +18,6 @@ class CodeSwitchContainer extends PureComponent {
 }
 
 class CodeBlock extends PureComponent {
-  state = {
-    isOpen: false,
-  };
-
   onChange = ev => {
     ev.preventDefault();
     ev.stopPropagation();
@@ -57,15 +53,8 @@ class CodeBlock extends PureComponent {
     setEditorState(EditorState.forceSelection(newEditorState, selection));
   };
 
-  cancelClicks = event => event.preventDefault();
-
   onSelectClick = event => {
-    const { setReadOnly } = this.props.blockProps;
     event.stopPropagation();
-    setReadOnly(true);
-    this.setState({
-      isOpen: true,
-    });
   };
 
   render() {

--- a/src/components/Code/index.js
+++ b/src/components/Code/index.js
@@ -1,28 +1,21 @@
 import React, { PureComponent } from "react";
 import { Map } from "immutable";
 import { EditorState, EditorBlock, Modifier } from "draft-js";
-import enhanceWithClickOutside from "react-click-outside";
 
 const alias = {
   javascript: "js",
   jsx: "js",
 };
 
-const CodeSwitchContainer = enhanceWithClickOutside(
-  class SwitchContainer extends PureComponent {
-    handleClickOutside() {
-      this.props.onClickOutside();
-    }
-
-    render() {
-      return (
-        <div contentEditable={false} onClick={this.props.onClick}>
-          {this.props.children}
-        </div>
-      );
-    }
+class CodeSwitchContainer extends PureComponent {
+  render() {
+    return (
+      <div contentEditable={false} onClick={this.props.onClick}>
+        {this.props.children}
+      </div>
+    );
   }
-);
+}
 
 class CodeBlock extends PureComponent {
   state = {
@@ -75,27 +68,6 @@ class CodeBlock extends PureComponent {
     });
   };
 
-  onClickOutside = () => {
-    if (!this.state.isOpen) {
-      return;
-    }
-    this.setState({
-      isOpen: false,
-    });
-    const {
-      getEditorState,
-      setReadOnly,
-      setEditorState,
-    } = this.props.blockProps;
-
-    setReadOnly(false);
-
-    const editorState = getEditorState();
-    const selection = editorState.getSelection();
-
-    setEditorState(EditorState.forceSelection(editorState, selection));
-  };
-
   render() {
     const {
       languages,
@@ -121,10 +93,7 @@ class CodeBlock extends PureComponent {
     return (
       <div>
         <EditorBlock {...this.props} />
-        <CodeSwitchContainer
-          onClickOutside={this.onClickOutside}
-          onClick={this.onSelectClick}
-        >
+        <CodeSwitchContainer onClick={this.onSelectClick}>
           {renderLanguageSelect({
             selectedLabel,
             selectedValue,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2898,10 +2898,6 @@ hoek@4.x.x:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
 
-hoist-non-react-statics@^2.1.1:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
-
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -5268,12 +5264,6 @@ react-addons-pure-render-mixin@^15.4.1:
 react-addons-test-utils@^15.4.1:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.6.0.tgz#062d36117fe8d18f3ba5e06eb33383b0b85ea5b9"
-
-react-click-outside@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/react-click-outside/-/react-click-outside-3.0.1.tgz#6e77e84d2f17afaaac26dbad743cbbf909f5e24c"
-  dependencies:
-    hoist-non-react-statics "^2.1.1"
 
 react-deep-force-update@^1.0.0:
   version "1.1.1"


### PR DESCRIPTION
This piece of code causes
https://github.com/withspectrum/spectrum/issues/2897, which breaks the app
for some people. I couldn't find anything that didn't work when removing
it, so I figure it's safe to remove it. :sweat_smile:

/cc @juliankrispel who might know why this was there in the first place and
why we might not be able to remove it.