### PR TITLE
Unsticky inline styles

### DIFF
--- a/src/__test__/plugin.test.js
+++ b/src/__test__/plugin.test.js
@@ -180,7 +180,7 @@ describe("draft-js-markdown-plugin", () => {
           expect(subject()).toBe("not-handled");
         });
 
-        it("resets curent inline style", () => {
+        it("resets current inline style", () => {
           currentRawContentState = {
             entityMap: {},
             blocks: [
@@ -544,6 +544,39 @@ describe("draft-js-markdown-plugin", () => {
                 currentEditorState,
                 " "
               );
+            });
+            it("unstickys inline style", () => {
+              currentRawContentState = {
+                entityMap: {},
+                blocks: [
+                  {
+                    key: "item1",
+                    text: "item1",
+                    type: "unstyled",
+                    depth: 0,
+                    inlineStyleRanges: [
+                      { offset: 0, length: 5, style: "BOLD" },
+                    ],
+                    entityRanges: [],
+                    data: {},
+                  },
+                ],
+              };
+
+              currentSelectionState = currentSelectionState.merge({
+                focusOffset: 5,
+                anchorOffset: 5,
+              });
+
+              expect(subject()).toBe("handled");
+              expect(store.setEditorState).toHaveBeenCalled();
+              newEditorState = store.setEditorState.mock.calls[0][0];
+              const block = newEditorState.getCurrentContent().getLastBlock();
+              const length = block.getLength();
+              expect(block.getInlineStyleAt(length - 1).toJS()).toEqual([]);
+              expect(block.getInlineStyleAt(length - 2).toJS()).toEqual([
+                "BOLD",
+              ]);
             });
           });
         });

--- a/src/index.js
+++ b/src/index.js
@@ -209,7 +209,7 @@ const unstickyInlineStyles = (character, editorState) => {
   const startOffset = selection.getStartOffset();
   const content = editorState.getCurrentContent();
   const block = content.getBlockForKey(selection.getStartKey());
-  const entity = block.getEntityAt(startOffset);
+  const entity = block.getEntityAt(startOffset - 1);
   if (entity !== null) return editorState;
 
   // If we're currently in a style, but the next character doesn't have a style (or doesn't exist)


### PR DESCRIPTION
This "unstickies" inline styles, so that when you type *bold* text, backspace to the ending edge of the bold text and start typing again the bold doesn't "stick" to the text, only when typing within it. This feels much better than before.

Recorded demo: ![](https://i.imgur.com/gWSLp06.gif)
Live demo: https://public-mffnxzocik.now.sh

/cc @brianlovin @wmertens this should be a fix for the issues you were having!