### PR TITLE
Add new plugin test suite

### DIFF
--- a/src/__test__/__snapshots__/plugin-new.test.js.snap
+++ b/src/__test__/__snapshots__/plugin-new.test.js.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`markdown should convert asteriks to bold text 1`] = `
+Object {
+  "blocks": Array [
+    Object {
+      "data": Object {},
+      "depth": 0,
+      "entityRanges": Array [],
+      "inlineStyleRanges": Array [
+        Object {
+          "length": 4,
+          "offset": 5,
+          "style": "BOLD",
+        },
+      ],
+      "key": "item1",
+      "text": "Some text",
+      "type": "unstyled",
+    },
+  ],
+  "entityMap": Object {},
+}
+`;
+
+exports[`markdown should not have sticky inline styles 1`] = `
+Object {
+  "blocks": Array [
+    Object {
+      "data": Object {},
+      "depth": 0,
+      "entityRanges": Array [],
+      "inlineStyleRanges": Array [
+        Object {
+          "length": 4,
+          "offset": 5,
+          "style": "BOLD",
+        },
+      ],
+      "key": "item1",
+      "text": "Some texta",
+      "type": "unstyled",
+    },
+  ],
+  "entityMap": Object {},
+}
+`;

--- a/src/__test__/plugin-new.test.js
+++ b/src/__test__/plugin-new.test.js
@@ -1,0 +1,114 @@
+import Draft, {
+  EditorState,
+  SelectionState,
+  ContentBlock,
+  convertToRaw,
+} from "draft-js";
+import createMarkdownPlugin from "../";
+
+describe("markdown", () => {
+  it("should convert asteriks to bold text", () => {
+    const { handleBeforeInput } = createMarkdownPlugin();
+    const setEditorState = jest.fn();
+    const before = EditorState.moveSelectionToEnd(
+      EditorState.createWithContent(
+        Draft.convertFromRaw({
+          entityMap: {},
+          blocks: [
+            {
+              key: "item1",
+              text: "Some *text",
+              type: "unstyled",
+              depth: 0,
+              inlineStyleRanges: [],
+              entityRanges: [],
+              data: {},
+            },
+          ],
+        })
+      )
+    );
+    expect(handleBeforeInput("*", before, { setEditorState })).toEqual(
+      "handled"
+    );
+    const raw = convertToRaw(
+      setEditorState.mock.calls[0][0].getCurrentContent()
+    );
+    expect(raw).toMatchSnapshot();
+  });
+
+  it("should not do anything to existing inline styles when within them", () => {
+    const { handleBeforeInput } = createMarkdownPlugin();
+    const setEditorState = jest.fn();
+    const boldInlineStyleRange = {
+      length: 4,
+      offset: 5,
+      style: "BOLD",
+    };
+    const before = EditorState.forceSelection(
+      EditorState.createWithContent(
+        Draft.convertFromRaw({
+          entityMap: {},
+          blocks: [
+            {
+              key: "item1",
+              text: "Some text",
+              type: "unstyled",
+              depth: 0,
+              inlineStyleRanges: [boldInlineStyleRange],
+              entityRanges: [],
+              data: {},
+            },
+          ],
+        })
+      ),
+      new SelectionState({
+        anchorKey: "item1",
+        anchorOffset: 6,
+        focusKey: "item1",
+        focusOffset: 6,
+        isBackward: false,
+        hasFocus: true,
+      })
+    );
+    expect(handleBeforeInput("a", before, { setEditorState })).toEqual(
+      "not-handled"
+    );
+  });
+
+  it("should not have sticky inline styles", () => {
+    const { handleBeforeInput } = createMarkdownPlugin();
+    const setEditorState = jest.fn();
+    const boldInlineStyleRange = {
+      length: 4,
+      offset: 5,
+      style: "BOLD",
+    };
+    const before = EditorState.moveSelectionToEnd(
+      EditorState.createWithContent(
+        Draft.convertFromRaw({
+          entityMap: {},
+          blocks: [
+            {
+              key: "item1",
+              text: "Some text",
+              type: "unstyled",
+              depth: 0,
+              inlineStyleRanges: [boldInlineStyleRange],
+              entityRanges: [],
+              data: {},
+            },
+          ],
+        })
+      )
+    );
+    expect(handleBeforeInput("a", before, { setEditorState })).toEqual(
+      "handled"
+    );
+    const raw = convertToRaw(
+      setEditorState.mock.calls[0][0].getCurrentContent()
+    );
+    expect(raw.blocks[0].inlineStyleRanges[0]).toEqual(boldInlineStyleRange);
+    expect(raw).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
How do you like this @juliankrispel? I feel like there could be a neater high-level abstraction on top of all this manual editor-, content- and selectionstate creation, but for now this is already much better than the old test suite!