### PR TITLE
[WIP] Test utils

### DIFF
--- a/src/__test__/__snapshots__/plugin-new.test.js.snap
+++ b/src/__test__/__snapshots__/plugin-new.test.js.snap
@@ -45,3 +45,20 @@ Object {
   "entityMap": Object {},
 }
 `;
+
+exports[`textToEditorState should have predictable block keys 1`] = `
+Object {
+  "blocks": Array [
+    Object {
+      "data": Object {},
+      "depth": 0,
+      "entityRanges": Array [],
+      "inlineStyleRanges": Array [],
+      "key": "block-0",
+      "text": "some text",
+      "type": "unstyled",
+    },
+  ],
+  "entityMap": Object {},
+}
+`;

--- a/src/__test__/__snapshots__/plugin-new.test.js.snap
+++ b/src/__test__/__snapshots__/plugin-new.test.js.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`markdown should convert asteriks to bold text 1`] = `
+Object {
+  "blocks": Array [
+    Object {
+      "data": Object {},
+      "depth": 0,
+      "entityRanges": Array [],
+      "inlineStyleRanges": Array [
+        Object {
+          "length": 4,
+          "offset": 5,
+          "style": "BOLD",
+        },
+      ],
+      "key": "item1",
+      "text": "Some text",
+      "type": "unstyled",
+    },
+  ],
+  "entityMap": Object {},
+}
+`;
+
+exports[`markdown should not have sticky inline styles 1`] = `
+Object {
+  "blocks": Array [
+    Object {
+      "data": Object {},
+      "depth": 0,
+      "entityRanges": Array [],
+      "inlineStyleRanges": Array [
+        Object {
+          "length": 4,
+          "offset": 5,
+          "style": "BOLD",
+        },
+      ],
+      "key": "item1",
+      "text": "Some texta",
+      "type": "unstyled",
+    },
+  ],
+  "entityMap": Object {},
+}
+`;

--- a/src/__test__/__snapshots__/plugin-new.test.js.snap
+++ b/src/__test__/__snapshots__/plugin-new.test.js.snap
@@ -14,7 +14,7 @@ Object {
           "style": "BOLD",
         },
       ],
-      "key": "item1",
+      "key": "block-0",
       "text": "Some text",
       "type": "unstyled",
     },

--- a/src/__test__/plugin-new.test.js
+++ b/src/__test__/plugin-new.test.js
@@ -80,24 +80,7 @@ describe("markdown", () => {
   it("should convert asteriks to bold text", () => {
     const { handleBeforeInput } = createMarkdownPlugin();
     const setEditorState = jest.fn();
-    const before = EditorState.moveSelectionToEnd(
-      EditorState.createWithContent(
-        Draft.convertFromRaw({
-          entityMap: {},
-          blocks: [
-            {
-              key: "item1",
-              text: "Some *text",
-              type: "unstyled",
-              depth: 0,
-              inlineStyleRanges: [],
-              entityRanges: [],
-              data: {},
-            },
-          ],
-        })
-      )
-    );
+    const before = textToEditorState`Some *text`;
     expect(handleBeforeInput("*", before, { setEditorState })).toEqual(
       "handled"
     );

--- a/src/__test__/plugin-new.test.js
+++ b/src/__test__/plugin-new.test.js
@@ -1,0 +1,114 @@
+import Draft, {
+  EditorState,
+  SelectionState,
+  ContentBlock,
+  convertToRaw,
+} from "draft-js";
+import createMarkdownPlugin from "../";
+
+describe("markdown", () => {
+  it("should convert asteriks to bold text", () => {
+    const { handleBeforeInput } = createMarkdownPlugin();
+    const setEditorState = jest.fn();
+    const before = EditorState.moveSelectionToEnd(
+      EditorState.createWithContent(
+        Draft.convertFromRaw({
+          entityMap: {},
+          blocks: [
+            {
+              key: "item1",
+              text: "Some *text",
+              type: "unstyled",
+              depth: 0,
+              inlineStyleRanges: [],
+              entityRanges: [],
+              data: {},
+            },
+          ],
+        })
+      )
+    );
+    expect(handleBeforeInput("*", before, { setEditorState })).toEqual(
+      "handled"
+    );
+    const raw = convertToRaw(
+      setEditorState.mock.calls[0][0].getCurrentContent()
+    );
+    expect(raw).toMatchSnapshot();
+  });
+
+  it("should not do anything to existing inline styles when within them", () => {
+    const { handleBeforeInput } = createMarkdownPlugin();
+    const setEditorState = jest.fn();
+    const boldInlineStyleRange = {
+      length: 4,
+      offset: 5,
+      style: "BOLD",
+    };
+    const before = EditorState.forceSelection(
+      EditorState.createWithContent(
+        Draft.convertFromRaw({
+          entityMap: {},
+          blocks: [
+            {
+              key: "item1",
+              text: "Some text",
+              type: "unstyled",
+              depth: 0,
+              inlineStyleRanges: [boldInlineStyleRange],
+              entityRanges: [],
+              data: {},
+            },
+          ],
+        })
+      ),
+      new SelectionState({
+        anchorKey: "item1",
+        anchorOffset: 6,
+        focusKey: "item1",
+        focusOffset: 6,
+        isBackward: false,
+        hasFocus: true,
+      })
+    );
+    expect(handleBeforeInput("a", before, { setEditorState })).toEqual(
+      "not-handled"
+    );
+  });
+
+  it("should not have sticky inline styles", () => {
+    const { handleBeforeInput } = createMarkdownPlugin();
+    const setEditorState = jest.fn();
+    const boldInlineStyleRange = {
+      length: 4,
+      offset: 5,
+      style: "BOLD",
+    };
+    const before = EditorState.moveSelectionToEnd(
+      EditorState.createWithContent(
+        Draft.convertFromRaw({
+          entityMap: {},
+          blocks: [
+            {
+              key: "item1",
+              text: "Some text",
+              type: "unstyled",
+              depth: 0,
+              inlineStyleRanges: [boldInlineStyleRange],
+              entityRanges: [],
+              data: {},
+            },
+          ],
+        })
+      )
+    );
+    expect(handleBeforeInput("a", before, { setEditorState })).toEqual(
+      "handled"
+    );
+    const raw = convertToRaw(
+      setEditorState.mock.calls[0][0].getCurrentContent()
+    );
+    expect(raw.blocks[0].inlineStyleRanges[0]).toEqual(boldInlineStyleRange);
+    expect(raw).toMatchSnapshot();
+  });
+});

--- a/src/__test__/plugin-new.test.js
+++ b/src/__test__/plugin-new.test.js
@@ -34,7 +34,16 @@ const textToEditorState = (strings, ...interpolations) => {
   const contentState = ContentState.createFromText(strings.join(""));
   const randomKeysEditorState = EditorState.createWithContent(contentState);
   const editorState = predictableKeys(randomKeysEditorState);
-  return EditorState.moveSelectionToEnd(editorState);
+  const plain = contentState.getPlainText();
+  const selectionIndex =
+    plain.indexOf("|") > -1 ? plain.indexOf("|") : plain.length;
+  return EditorState.forceSelection(
+    editorState,
+    editorState.getSelection().merge({
+      anchorOffset: selectionIndex,
+      focusOffset: selectionIndex,
+    })
+  );
 };
 
 describe("textToEditorState", () => {
@@ -56,7 +65,13 @@ describe("textToEditorState", () => {
 
   it("should have the selection at the end by default", () => {
     expect(textToEditorState`some text`.getSelection().serialize()).toEqual(
-      "Anchor: block-0:9, Focus: block-0:9, Is Backward: false, Has Focus: false"
+      "Anchor: block-0:9, Focus: block-0:9, Is Backward: false, Has Focus: true"
+    );
+  });
+
+  it("should allow you to move the selection with |", () => {
+    expect(textToEditorState`some| text`.getSelection().serialize()).toEqual(
+      "Anchor: block-0:4, Focus: block-0:4, Is Backward: false, Has Focus: true"
     );
   });
 });

--- a/src/__test__/plugin-new.test.js
+++ b/src/__test__/plugin-new.test.js
@@ -1,10 +1,22 @@
 import Draft, {
+  ContentState,
   EditorState,
   SelectionState,
   ContentBlock,
   convertToRaw,
 } from "draft-js";
 import createMarkdownPlugin from "../";
+
+const textToEditorState = (strings, ...interpolations) => {
+  const contentState = ContentState.createFromText(strings.join(""));
+  return EditorState.createWithContent(contentState);
+};
+
+describe.only("textToEditorState", () => {
+  it("should return DraftJS EditorState", () => {
+    expect(textToEditorState`some text`).toBeInstanceOf(EditorState);
+  });
+});
 
 describe("markdown", () => {
   it("should convert asteriks to bold text", () => {


### PR DESCRIPTION
**Note: This is based on #86, so until that is merged this will also show those changes. Click the following link to see the diff between this and #86, which should be a lot more helpful: https://github.com/withspectrum/draft-js-markdown-plugin/compare/new-test-suite...withspectrum:draftjs-test-utils**

This is a rough first draft for a DraftJS test util called `textToEditorState`. Usage looks like this right now:

```JS
// | denotes the cursor position, i.e. selection state
const editorState = textToEditorState`some| text`;
```

**TODO:**

- [ ] Handle interpolations
- [ ] Figure out how to denote inline style ranges
- [ ] Figure out how to denote blocks and block types
- [ ] Figure out how to denote selection state, including selection ranges
- [ ] Once it's all done and we're happy with it publish as `draft-js-test-utils`

@juliankrispel @nikgraf input here would be very much appreciated :pray: 