### PR TITLE
do not apply inline styles in the middle of the word

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -3,10 +3,10 @@ import { CHECKABLE_LIST_ITEM } from "draft-js-checkable-list-item";
 export const CODE_BLOCK_REGEX = /^```([\w-]+)?\s*$/;
 
 export const inlineMatchers = {
-  BOLD: [/\*(.+)\*$/g],
-  ITALIC: [/_(.+)_$/g],
-  CODE: [/`([^`]+)`$/g],
-  STRIKETHROUGH: [/~(.+)~$/g],
+  BOLD: [/(?:^|\s)\*(.+)\*$/g],
+  ITALIC: [/(?:^|\s)_(.+)_$/g],
+  CODE: [/(?:^|\s)`([^`]+)`$/g],
+  STRIKETHROUGH: [/(?:^|\s)~(.+)~$/g],
 };
 
 export const CODE_BLOCK_TYPE = "code-block";

--- a/src/modifiers/__test__/handleInlineStyle-test.js
+++ b/src/modifiers/__test__/handleInlineStyle-test.js
@@ -54,7 +54,7 @@ describe("handleInlineStyle", () => {
         blocks: [
           {
             key: "item1",
-            text: "*h~ello _inline~_ style",
+            text: "*~hello _inline~_ style",
             type: "unstyled",
             depth: 0,
             inlineStyleRanges: [],
@@ -73,7 +73,7 @@ describe("handleInlineStyle", () => {
             depth: 0,
             inlineStyleRanges: [
               { length: 12, offset: 0, style: "BOLD" },
-              { length: 11, offset: 1, style: "STRIKETHROUGH" },
+              { length: 12, offset: 0, style: "STRIKETHROUGH" },
               { length: 6, offset: 6, style: "ITALIC" },
             ],
             entityRanges: [],
@@ -467,6 +467,48 @@ describe("handleInlineStyle", () => {
         anchorOffset: 13,
         focusKey: "item1",
         focusOffset: 13,
+        isBackward: false,
+        hasFocus: true,
+      }),
+    },
+    "does not convert markdown in the middle of the word": {
+      character: "*",
+      before: {
+        entityMap: {},
+        blocks: [
+          {
+            key: "item1",
+            text: "*h~ello _inline~_ style",
+            type: "unstyled",
+            depth: 0,
+            inlineStyleRanges: [],
+            entityRanges: [],
+            data: {},
+          },
+        ],
+      },
+      after: {
+        entityMap: {},
+        blocks: [
+          {
+            key: "item1",
+            text: "h~ello inline~ style",
+            type: "unstyled",
+            depth: 0,
+            inlineStyleRanges: [
+              { length: 14, offset: 0, style: "BOLD" },
+              { length: 7, offset: 7, style: "ITALIC" },
+            ],
+            entityRanges: [],
+            data: {},
+          },
+        ],
+      },
+      selection: new SelectionState({
+        anchorKey: "item1",
+        anchorOffset: 17,
+        focusKey: "item1",
+        focusOffset: 17,
         isBackward: false,
         hasFocus: true,
       }),

--- a/src/modifiers/handleInlineStyle.js
+++ b/src/modifiers/handleInlineStyle.js
@@ -14,6 +14,10 @@ const handleChange = (editorState, line, whitelist) => {
         do {
           matchArr = re.exec(line);
           if (matchArr) {
+            if (matchArr[0][0].match(/^\s/)) {
+              matchArr[0] = matchArr[0].replace(/^\s/, "");
+              matchArr.index += 1;
+            }
             newEditorState = changeCurrentInlineStyle(
               newEditorState,
               matchArr,


### PR DESCRIPTION
fixes for https://github.com/withspectrum/draft-js-markdown-plugin/issues/98