### PR TITLE
Fix strange behavior on pressing '#' when selection lies across multi blocks

### DIFF
--- a/src/modifiers/changeCurrentBlockType.js
+++ b/src/modifiers/changeCurrentBlockType.js
@@ -32,13 +32,19 @@ const changeCurrentBlockType = (
   }
   const newBlock = startBlock.merge({ type, data, text, characterList });
 
+  // It seems that there is no way to get the right selectionAfter.
+  // Use the same trivial solution as the old version
   const startOffset = selection.getStartOffset();
+  var afterOffset = text.length;
+  if (startOffset < afterOffset) {
+    afterOffset = startOffset;
+  }
 
   selection = selection.merge({
     anchorKey: startKey,
     focusKey: startKey,
-    anchorOffset: startOffset,
-    focusOffset: startOffset,
+    anchorOffset: afterOffset,
+    focusOffset: afterOffset,
   });
 
   const newContentState = currentContent.merge({

--- a/src/modifiers/changeCurrentBlockType.js
+++ b/src/modifiers/changeCurrentBlockType.js
@@ -1,4 +1,4 @@
-import { EditorState } from "draft-js";
+import { EditorState, CharacterMetadata } from "draft-js";
 
 const changeCurrentBlockType = (
   editorState,
@@ -8,23 +8,41 @@ const changeCurrentBlockType = (
 ) => {
   const currentContent = editorState.getCurrentContent();
   let selection = editorState.getSelection();
-  const key = selection.getStartKey();
-  const blockMap = currentContent.getBlockMap();
-  const block = blockMap.get(key);
-  const data = block.getData().merge(blockMetadata);
-  const newBlock = block.merge({ type, data, text: text });
-
-  const lastOffset = text.length;
-
-  if (selection.getFocusOffset() > lastOffset) {
-    selection = selection.merge({
-      anchorOffset: lastOffset,
-      focusOffset: lastOffset,
-    });
+  const startKey = selection.getStartKey();
+  const endKey = selection.getEndKey();
+  var blockMap = currentContent.getBlockMap();
+  const startBlock = blockMap.get(startKey);
+  const endBlock = blockMap.get(endKey);
+  if (startKey !== endKey) {
+    // blocks after the startKey should be removed
+    var currentKey = startKey;
+    const keysToRemove = [];
+    do {
+      currentKey = currentContent.getKeyAfter(currentKey);
+      keysToRemove.push(currentKey);
+    } while (currentKey !== endKey);
+    keysToRemove.forEach(key => (blockMap = blockMap.delete(key)));
   }
+  const data = startBlock.getData().merge(blockMetadata);
+  const characterList = [];
+  for (var i = 0; i < text.length; ++i) {
+    // it seems that current API can not make me figure out the correct
+    // CharacterMetadata for each character in the text
+    characterList.push(CharacterMetadata.create());
+  }
+  const newBlock = startBlock.merge({ type, data, text, characterList });
+
+  const startOffset = selection.getStartOffset();
+
+  selection = selection.merge({
+    anchorKey: startKey,
+    focusKey: startKey,
+    anchorOffset: startOffset,
+    focusOffset: startOffset,
+  });
 
   const newContentState = currentContent.merge({
-    blockMap: blockMap.set(key, newBlock),
+    blockMap: blockMap.set(startKey, newBlock),
     selectionAfter: selection,
   });
 

--- a/src/modifiers/handleBlockType.js
+++ b/src/modifiers/handleBlockType.js
@@ -27,16 +27,14 @@ const handleBlockType = (whiteList, editorState, character) => {
   const startKey = currentSelection.getStartKey();
   const endKey = currentSelection.getEndKey();
   const startOffset = currentSelection.getStartOffset();
-  const endOffset = currentSelectino.getEndOffset();
-  const startText = currentContent
-    .getBlockForKey(startKey)
-    .getText();
-  const endText = currentContent
-    .getBlockForKey(endKey)
-    .getText()
-  const line = [startText.slice(0, startOffset),
-                character,
-                endText.slice(endOffset)].join("");
+  const endOffset = currentSelection.getEndOffset();
+  const startText = currentContent.getBlockForKey(startKey).getText();
+  const endText = currentContent.getBlockForKey(endKey).getText();
+  const line = [
+    startText.slice(0, startOffset),
+    character,
+    endText.slice(endOffset),
+  ].join("");
 
   const blockType = RichUtils.getCurrentBlockType(editorState);
 

--- a/src/modifiers/handleBlockType.js
+++ b/src/modifiers/handleBlockType.js
@@ -23,15 +23,21 @@ const headerReg = /^(#+)\s+/;
 
 const handleBlockType = (whiteList, editorState, character) => {
   const currentSelection = editorState.getSelection();
-  const key = currentSelection.getStartKey();
-  const text = editorState
-    .getCurrentContent()
-    .getBlockForKey(key)
+  const currentContent = editorState.getCurrentContent();
+  const startKey = currentSelection.getStartKey();
+  const endKey = currentSelection.getEndKey();
+  const startOffset = currentSelection.getStartOffset();
+  const endOffset = currentSelectino.getEndOffset();
+  const startText = currentContent
+    .getBlockForKey(startKey)
     .getText();
-  const position = currentSelection.getAnchorOffset();
-  const line = [text.slice(0, position), character, text.slice(position)].join(
-    ""
-  );
+  const endText = currentContent
+    .getBlockForKey(endKey)
+    .getText()
+  const line = [startText.slice(0, startOffset),
+                character,
+                endText.slice(endOffset)].join("");
+
   const blockType = RichUtils.getCurrentBlockType(editorState);
 
   const headerMatch = line.match(headerReg);


### PR DESCRIPTION
For example
```
123
456 789
```
Selection goes from `1` to `6`(or in reverse direction). If I press `#`, I would hope to see the text changes to the following:
```
# 789
```
which will be rendered as 
# 789

The old version will behave strange under such circumstances. I have fixed that :)