### PR TITLE
unstick styles after backspace

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -205,9 +205,6 @@ function checkReturnForState(config, editorState, ev) {
 const unstickyInlineStyles = (character, editorState) => {
   const selection = editorState.getSelection();
   if (!selection.isCollapsed()) return editorState;
-  if (editorState.getLastChangeType() !== "md-to-inline-style") {
-    return editorState;
-  }
 
   const startOffset = selection.getStartOffset();
   const content = editorState.getCurrentContent();
@@ -225,6 +222,9 @@ const unstickyInlineStyles = (character, editorState) => {
     );
     if (previousBlockStyle.size === 0) return editorState;
   } else {
+    if (editorState.getLastChangeType() !== "md-to-inline-style") {
+      return editorState;
+    }
     const style = block.getInlineStyleAt(startOffset - 1);
     if (style.size === 0) return editorState;
   }


### PR DESCRIPTION
I found another issue with unsticking styles:
![kapture 2018-10-24 at 19 19 45](https://user-images.githubusercontent.com/1834162/47445569-eb3b6b80-d7c1-11e8-848c-91448473008f.gif)

Doing previous PR https://github.com/withspectrum/draft-js-markdown-plugin/pull/141 I forgot that we also clear styles on the starting of the new line https://github.com/withspectrum/draft-js-markdown-plugin/blob/master/src/index.js#L373 and `unstickyInlineStyles` function in that case should work even if the previous block styles were changed by another plugin. 